### PR TITLE
Access spec declaration methods

### DIFF
--- a/busted.lua
+++ b/busted.lua
@@ -1,0 +1,3 @@
+-- This is a dummy file so it can be used in busted's specs
+-- without adding ./?/init.lua to the lua path
+return require 'busted.init'

--- a/busted/init.lua
+++ b/busted/init.lua
@@ -13,15 +13,15 @@ local function shuffle(t, seed)
   return t
 end
 
-return function(busted)
-  local function remove(descriptors, element)
-    for _, descriptor in ipairs(descriptors) do
-      element.env[descriptor] = function(...)
-        error("'" .. descriptor .. "' not supported inside current context block", 2)
-      end
+local function remove(descriptors, element)
+  for _, descriptor in ipairs(descriptors) do
+    element.env[descriptor] = function(...)
+      error("'" .. descriptor .. "' not supported inside current context block", 2)
     end
   end
+end
 
+local function init(busted)
   local function exec(descriptor, element)
     if not element.env then element.env = {} end
 
@@ -201,3 +201,15 @@ return function(busted)
 
   return busted
 end
+
+return setmetatable({}, {
+  __call = function(self, busted)
+    init(busted)
+
+    return setmetatable(self, {
+      __index = function(self, descriptor)
+        return busted.executors[descriptor]
+      end
+    })
+  end
+})

--- a/busted/init.lua
+++ b/busted/init.lua
@@ -209,6 +209,10 @@ return setmetatable({}, {
     return setmetatable(self, {
       __index = function(self, descriptor)
         return busted.executors[descriptor]
+      end,
+
+      __newindex = function(self, key, value)
+        error('Attempt to modify busted')
       end
     })
   end

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -52,7 +52,7 @@ return function(options)
 
   local luacov = require 'busted.modules.luacov'()
 
-  require 'busted.init'(busted)
+  require 'busted'(busted)
 
   -- Default cli arg values
   local defaultOutput = path.is_windows and 'plainTerminal' or 'utfTerminal'

--- a/spec/executors_spec.lua
+++ b/spec/executors_spec.lua
@@ -37,4 +37,15 @@ describe('tests require "busted"', function()
     assert.is_equal(before_each, require 'busted'.before_each)
     assert.is_equal(after_each, require 'busted'.after_each)
   end)
+
+  it('functions cannot be overwritten', function()
+    local foo = function() assert(false) end
+    assert.has_error(function() require 'busted'.it = foo end)
+    assert.is_equal(it, require 'busted'.it)
+  end)
+
+  it('cannot add new fields', function()
+    local bar = function() assert(false) end
+    assert.has_error(function() require 'busted'.foo = bar end)
+  end)
 end)

--- a/spec/executors_spec.lua
+++ b/spec/executors_spec.lua
@@ -1,0 +1,40 @@
+
+describe('tests require "busted"', function()
+  local describe = describe
+  local context = context
+  local it = it
+  local pending = pending
+  local spec = spec
+  local test = test
+  local setup = setup
+  local teardown = teardown
+  local before_each = before_each
+  local after_each = after_each
+
+  it('does not import init', function()
+    assert.is_nil(require 'busted'.init)
+  end)
+
+  it('imports file executor', function()
+    assert.is_function(require 'busted'.file)
+  end)
+
+  it('imports describe/it/pending', function()
+    assert.is_equal(describe, require 'busted'.describe)
+    assert.is_equal(it, require 'busted'.it)
+    assert.is_equal(pending, require 'busted'.pending)
+  end)
+
+  it('imports aliases', function()
+    assert.is_equal(context, require 'busted'.context)
+    assert.is_equal(spec, require 'busted'.spec)
+    assert.is_equal(test, require 'busted'.test)
+  end)
+
+  it('imports support functions', function()
+    assert.is_equal(setup, require 'busted'.setup)
+    assert.is_equal(teardown, require 'busted'.teardown)
+    assert.is_equal(before_each, require 'busted'.before_each)
+    assert.is_equal(after_each, require 'busted'.after_each)
+  end)
+end)


### PR DESCRIPTION
This address issue #320, allowing helper modules to declare tests like:
```lua
-- test_helper.lua
local it = require 'busted'.it

local function make_test(a, b)
  it('should check ' .. a .. ' same as ' .. b, function()
    assert.same(a, b)
  end)
end

return {
  make_test = make_test
}
```
And then use the helper modules like:
```lua
-- test_spec.lua
local make_test = require 'test_helpers'.make_test
describe('things', function()
  make_test(1, 2)
  make_test(4, 4)
end)
```
This is done by exposing the busted executor functions via `require 'busted'` ~~or `require 'busted.executors'`~~ so they can be imported by helper modules.
