### PR TITLE
Display error and failure messages in the order they occur

### DIFF
--- a/busted/outputHandlers/base.lua
+++ b/busted/outputHandlers/base.lua
@@ -101,7 +101,6 @@ return function(busted)
 
     local isError
     local insertTable
-    local id = tostring(element)
 
     if status == 'success' then
       insertTable = handler.successes
@@ -118,15 +117,18 @@ return function(busted)
       isError = true
     end
 
-    insertTable[id] = handler.format(element, parent, element.message, debug, isError)
+    local formatted = handler.format(element, parent, element.message, debug, isError)
 
+    local id = tostring(element)
     if handler.inProgress[id] then
       for k, v in pairs(handler.inProgress[id]) do
-        insertTable[id][k] = v
+        formatted[k] = v
       end
 
       handler.inProgress[id] = nil
     end
+
+    table.insert(insertTable, formatted)
 
     return nil, true
   end


### PR DESCRIPTION
This change updates the order that error, failure, and pending messages are displayed such that they are reported in the same order as when they occurred. Messages are still grouped according to their type, where all pending messages are grouped together, all failure messages are grouped together, etc. This allows for the same exact output messages to be generated in the same exact order each time a test suite is executed
with the same command-line options.