### PR TITLE
Support loading output handler via Lua search path

### DIFF
--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -24,8 +24,8 @@ else
 fi
 
 cd ..
-wget -O - http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
-cd luarocks-2.1.2
+wget -O - http://luarocks.org/releases/luarocks-2.2.0.tar.gz | tar xz
+cd luarocks-2.2.0
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then
   ./configure --with-lua-include=/usr/local/include/luajit-2.0;

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -2,6 +2,8 @@
 # Sets up Lua and Luarocks. 
 # LUA must be "Lua 5.1", "Lua 5.2" or "LuaJIT 2.0". 
 
+set -e
+
 echo 'rocks_servers = {
   "http://rocks.moonscript.org/",
   "http://luarocks.org/repositories/rocks"

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -9,22 +9,22 @@ echo 'rocks_servers = {
 
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then
-  curl http://luajit.org/download/LuaJIT-2.0.2.tar.gz | tar xz
+  wget -O - http://luajit.org/download/LuaJIT-2.0.2.tar.gz | tar xz
   cd LuaJIT-2.0.2
   make && sudo make install INSTALL_TSYMNAME=lua;
 else
   if [ "$LUA" == "Lua 5.1" ]; then
-    curl http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
+    wget -O - http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
     cd lua-5.1.5;
   elif [ "$LUA" == "Lua 5.2" ]; then
-    curl http://www.lua.org/ftp/lua-5.2.3.tar.gz | tar xz
+    wget -O - http://www.lua.org/ftp/lua-5.2.3.tar.gz | tar xz
     cd lua-5.2.3;
   fi
   sudo make linux install;
 fi
 
 cd ..
-curl http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
+wget -O - http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
 cd luarocks-2.1.2
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then

--- a/busted/modules/output_handler_loader.lua
+++ b/busted/modules/output_handler_loader.lua
@@ -8,13 +8,17 @@ return function()
       if output:match('.lua$') or output:match('.moon$') then
         handler = loadfile(path.normpath(opath))()
       else
-        handler = require('busted.outputHandlers.'..output)
+        handler = require('busted.outputHandlers.' .. output)
       end
     end)
 
     if not success then
+      success, err = pcall(function() handler = require(output) end)
+    end
+
+    if not success then
       busted.publish({ 'error', 'output' }, { descriptor = 'output', name = output }, nil, err, {})
-      handler = require('busted.outputHandlers.'..defaultOutput)
+      handler = require('busted.outputHandlers.' .. defaultOutput)
     end
 
     return handler(options, busted)

--- a/spec/cl_spec.lua
+++ b/spec/cl_spec.lua
@@ -223,6 +223,15 @@ describe('Tests the busted command-line options', function()
     error_end()
   end)
 
+  it('tests running with --output specified with module in lua path', function()
+    local success, exitcode
+    error_start()
+    success, exitcode = execute('bin/busted --pattern=cl_success.lua$ --output=busted.outputHandlers.TAP')
+    assert.is_true(success)
+    assert.is_equal(0, exitcode)
+    error_end()
+  end)
+
   it('tests no tests to exit with a fail-exitcode', function()
     local success, exitcode
     error_start()


### PR DESCRIPTION
This allows an output handler to be loaded from a module found in the Lua search path (or path specified by the --lpath option). The output handler can still be loaded from a lua or moonscript file as well. If the output handler specified on the command line cannot be found in `busted/outputHandlers/`, then attempt to load
the output handler as if it were in the Lua module search path.