### PR TITLE
Fix issue #327 busted --lpath isn't functioning 

### DIFF
--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -24,8 +24,8 @@ else
 fi
 
 cd ..
-wget -O - http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
-cd luarocks-2.1.2
+wget -O - http://luarocks.org/releases/luarocks-2.2.0.tar.gz | tar xz
+cd luarocks-2.2.0
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then
   ./configure --with-lua-include=/usr/local/include/luajit-2.0;

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -2,6 +2,8 @@
 # Sets up Lua and Luarocks. 
 # LUA must be "Lua 5.1", "Lua 5.2" or "LuaJIT 2.0". 
 
+set -e
+
 echo 'rocks_servers = {
   "http://rocks.moonscript.org/",
   "http://luarocks.org/repositories/rocks"

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -9,22 +9,22 @@ echo 'rocks_servers = {
 
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then
-  curl http://luajit.org/download/LuaJIT-2.0.2.tar.gz | tar xz
+  wget -O - http://luajit.org/download/LuaJIT-2.0.2.tar.gz | tar xz
   cd LuaJIT-2.0.2
   make && sudo make install INSTALL_TSYMNAME=lua;
 else
   if [ "$LUA" == "Lua 5.1" ]; then
-    curl http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
+    wget -O - http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
     cd lua-5.1.5;
   elif [ "$LUA" == "Lua 5.2" ]; then
-    curl http://www.lua.org/ftp/lua-5.2.3.tar.gz | tar xz
+    wget -O - http://www.lua.org/ftp/lua-5.2.3.tar.gz | tar xz
     cd lua-5.2.3;
   fi
   sudo make linux install;
 fi
 
 cd ..
-curl http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
+wget -O - http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
 cd luarocks-2.1.2
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then

--- a/busted/modules/configuration_loader.lua
+++ b/busted/modules/configuration_loader.lua
@@ -14,8 +14,7 @@ return function()
       local runConfig = configFile[run]
 
       if type(runConfig) == 'table' then
-
-        config = tablex.merge(config, runConfig, true)
+        config = tablex.merge(runConfig, config, true)
         return config
       else
         return config, 'Task `' .. run .. '` not found, or not a table.'
@@ -23,7 +22,7 @@ return function()
     end
 
     if configFile and type(configFile.default) == 'table' then
-      config = tablex.merge(config, configFile.default, true)
+      config = tablex.merge(configFile.default, config, true)
     end
 
     return config

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -86,7 +86,7 @@ return function(options)
   end
 
   -- Load current working directory
-  local fpath = cliArgs.d
+  local fpath = utils.normpath(cliArgs.d)
 
   -- Load busted config file if available
   local configFile = { }
@@ -123,15 +123,15 @@ return function(options)
   -- Add additional package paths based on lpath and cpath cliArgs
   if #cliArgs.lpath > 0 then
     lpathprefix = cliArgs.lpath
-    lpathprefix = lpathprefix:gsub('^%.[/%\\]', fpath )
-    lpathprefix = lpathprefix:gsub(';%.[/%\\]', ';' .. fpath)
+    lpathprefix = lpathprefix:gsub('^%.([/%\\])', fpath .. '%1')
+    lpathprefix = lpathprefix:gsub(';%.([/%\\])', ';' .. fpath .. '%1')
     package.path = (lpathprefix .. ';' .. package.path):gsub(';;',';')
   end
 
   if #cliArgs.cpath > 0 then
     cpathprefix = cliArgs.cpath
-    cpathprefix = cpathprefix:gsub('^%.[/%\\]', fpath )
-    cpathprefix = cpathprefix:gsub(';%.[/%\\]', ';' .. fpath)
+    cpathprefix = cpathprefix:gsub('^%.([/%\\])', fpath .. '%1')
+    cpathprefix = cpathprefix:gsub(';%.([/%\\])', ';' .. fpath .. '%1')
     package.cpath = (cpathprefix .. ';' .. package.cpath):gsub(';;',';')
   end
 

--- a/spec/cl_lua_path.lua
+++ b/spec/cl_lua_path.lua
@@ -1,0 +1,8 @@
+-- supporting testfile; belongs to 'cl_spec.lua'
+
+describe('Tests --lpath prepends to package.path', function()
+  it('require test module', function()
+    local mod = require('cl_test_module')
+    assert.is_equal('test module', mod)
+  end)
+end)

--- a/spec/cl_spec.lua
+++ b/spec/cl_spec.lua
@@ -167,6 +167,13 @@ describe('Tests the busted command-line options', function()
     assert.is_equal(expected, result)
   end)
 
+  it('tests running with --lpath specified', function()
+    local success, exitcode
+    success, exitcode = execute('bin/busted --lpath="spec/?.lua" spec/cl_lua_path.lua')
+    assert.is_true(success)
+    assert.is_equal(0, exitcode)
+  end)
+
   it('tests running with --lang specified', function()
     local success, exitcode
     error_start()

--- a/spec/cl_test_module.lua
+++ b/spec/cl_test_module.lua
@@ -1,0 +1,1 @@
+return 'test module'


### PR DESCRIPTION
This fixes issue #327
- The default `.busted` task was overriding the command-line argument for `--lpath`