### PR TITLE
Access for busted root context environment variables

### DIFF
--- a/busted/init.lua
+++ b/busted/init.lua
@@ -212,11 +212,12 @@ end
 
 return setmetatable({}, {
   __call = function(self, busted)
+    local root = busted.context.get()
     init(busted)
 
     return setmetatable(self, {
-      __index = function(self, descriptor)
-        return busted.executors[descriptor]
+      __index = function(self, key)
+        return rawget(root.env, key) or busted.executors[key]
       end,
 
       __newindex = function(self, key, value)

--- a/spec/executors_spec.lua
+++ b/spec/executors_spec.lua
@@ -38,6 +38,13 @@ describe('tests require "busted"', function()
     assert.is_equal(after_each, require 'busted'.after_each)
   end)
 
+  it('imports assert and mocks', function()
+    assert.is_equal(assert, require 'busted'.assert)
+    assert.is_equal(spy, require 'busted'.spy)
+    assert.is_equal(mock, require 'busted'.mock)
+    assert.is_equal(stub, require 'busted'.stub)
+  end)
+
   it('functions cannot be overwritten', function()
     local foo = function() assert(false) end
     assert.has_error(function() require 'busted'.it = foo end)


### PR DESCRIPTION
This allows helper modules to use variables/functions declared in the busted environment, such as `assert`, `spy`, `mock`, `stub`, etc. This complements the spec declarations methods (`describe`, `it`, etc.), which can already be used by helper modules.