### PR TITLE
Default output handler depends on stdout is a tty

### DIFF
--- a/busted-2.0.rc6-0.rockspec
+++ b/busted-2.0.rc6-0.rockspec
@@ -25,6 +25,7 @@ dependencies = {
   'say >= 1.2-1',
   'luassert >= 1.7.4-0',
   'ansicolors >= 1.0-1',
+  'lua-term >= 0.1-1',
   'penlight >= 1.0.0-1',
   'mediator_lua >= 1.1-3',
 }

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -3,6 +3,7 @@
 local getfenv = require 'busted.compatibility'.getfenv
 local setfenv = require 'busted.compatibility'.setfenv
 local path = require 'pl.path'
+local term = require 'term'
 local utils = require 'busted.utils'
 local loaded = false
 
@@ -22,7 +23,7 @@ return function(options)
   require 'busted'(busted)
 
   -- Default cli arg values
-  local defaultOutput = path.is_windows and 'plainTerminal' or 'utfTerminal'
+  local defaultOutput = term.isatty(io.stdout) and 'utfTerminal' or 'plainTerminal'
   local defaultLoaders = 'lua,moonscript'
   local defaultPattern = '_spec'
   local defaultSeed = 'os.time()'


### PR DESCRIPTION
Set default output handler to `utfTerminal` if `stdout` is a tty, otherwise set the default output handler to `plainTerminal`.

This allows file redirection to automatically default to `plainTerminal`.  For example
```
$ busted > log.txt
```
will use `plainTerminal`, while
```
$ busted
```
will use `utfTerminal`.

In addition, there is no need to have any special logic for Windows since the `ansicolors` module already takes care of this by removing any ansi color codes when running on Windows, only enabling ansi color codes when ansicon is present.