### PR TITLE
Fix double counting of errors

### DIFF
--- a/busted/init.lua
+++ b/busted/init.lua
@@ -155,7 +155,7 @@ local function init(busted)
     local pass, ancestor = execAll('before_each', parent, true)
 
     if pass then
-      status:update(busted.safe('element', element.run, element))
+      status:update(busted.safe('it', element.run, element))
     else
       updateErrorStatus('before_each')
     end


### PR DESCRIPTION
This fixes the case where errors are double counted when there is an error in a support function (`setup`, `teardown`, `before_each`, `after_each`)