### PR TITLE
Update status 'dot' characters for utf terminal

### DIFF
--- a/busted/outputHandlers/utfTerminal.lua
+++ b/busted/outputHandlers/utfTerminal.lua
@@ -5,10 +5,10 @@ local pretty = require 'pl.pretty'
 return function(options, busted)
   local handler = require 'busted.outputHandlers.base'(busted)
 
-  local successDot =  ansicolors('%{green}●')
-  local failureDot =  ansicolors('%{red}●')
-  local errorDot =  ansicolors('%{magenta}●')
-  local pendingDot = ansicolors('%{yellow}●')
+  local successDot = ansicolors('%{green}●')
+  local failureDot = ansicolors('%{red}◼')
+  local errorDot   = ansicolors('%{magenta}✱')
+  local pendingDot = ansicolors('%{yellow}◌')
 
   local pendingDescription = function(pending)
     local name = pending.name


### PR DESCRIPTION
Use different characters for success, failure, error, and pending status dots:
* Success - filled circle
* Failure - filled square
* Error   - heavy asterisk
* Pending - dotted circle

```
●●◼◼✱✱◌◌
2 successes / 2 failures / 2 errors / 2 pending : 0.0 seconds
```