### PR TITLE
Fix #333: junit dies when trace is nil

### DIFF
--- a/busted/outputHandlers/junit.lua
+++ b/busted/outputHandlers/junit.lua
@@ -54,7 +54,10 @@ return function(options, busted)
   handler.errorFile = function(element, parent, message, trace)
     xml_doc.attr.errors = xml_doc.attr.errors + 1
     xml_doc:addtag('error')
-    xml_doc:text(trace.traceback)
+    xml_doc:text(message)
+    if trace then
+      xml_doc:text(trace.traceback)
+    end
     xml_doc:up()
 
     return nil, true


### PR DESCRIPTION
This also adds message to the output, since it may be the only
information we have if trace is nil.