### PR TITLE
Add stack trace to TAP failure message

### DIFF
--- a/busted/outputHandlers/TAP.lua
+++ b/busted/outputHandlers/TAP.lua
@@ -13,12 +13,13 @@ return function(options, busted)
 
     for i,t in pairs(handler.successes) do
       counter = counter + 1
-      print( success:format( counter, t.name ))
+      print(success:format(counter, t.name))
     end
 
     showFailure = function(t)
       counter = counter + 1
       local message = t.message
+      local trace = t.trace or {}
 
       if message == nil then
         message = 'Nil error'
@@ -26,9 +27,12 @@ return function(options, busted)
         message = pretty.write(message)
       end
 
-      print( failure:format( counter, t.name ))
+      print(failure:format(counter, t.name))
       print('# ' .. t.element.trace.short_src .. ' @ ' .. t.element.trace.currentline)
-      print('# Failure message: ' .. message:gsub('\n', '\n# ' ))
+      print('# Failure message: ' .. message:gsub('\n', '\n# '))
+      if options.verbose and trace.traceback then
+        print('# ' .. trace.traceback:gsub('^\n', '', 1):gsub('\n', '\n# '))
+      end
     end
 
     for i,t in pairs(handler.errors) do


### PR DESCRIPTION
Enable stack trace info in TAP failures with the verbose option.
```
$ busted -v -o TAP
1..6
ok 1 - Tests success1
ok 2 - Tests success2
not ok 3 - Tests error1
# ./spec/test_spec.lua @ 23
# Failure message: ./spec/test_spec.lua:24: always throws error
# stack traceback:
#       ./spec/test_spec.lua:24: in function <./spec/test_spec.lua:23>
#
not ok 4 - Tests error2
# ./spec/test_spec.lua @ 27
# Failure message: ./spec/test_spec.lua:28: always throws error
# stack traceback:
#       ./spec/test_spec.lua:28: in function <./spec/test_spec.lua:27>
#
not ok 5 - Tests failure1
# ./spec/test_spec.lua @ 15
# Failure message: ./spec/test_spec.lua:16: always fails
# stack traceback:
#       ./spec/test_spec.lua:16: in function <./spec/test_spec.lua:15>
#
not ok 6 - Tests failure2
# ./spec/test_spec.lua @ 19
# Failure message: ./spec/test_spec.lua:20: always fails
# stack traceback:
#       ./spec/test_spec.lua:20: in function <./spec/test_spec.lua:19>
#
```