### PR TITLE
Insert junit timestamp in each test suite

### DIFF
--- a/busted/outputHandlers/junit.lua
+++ b/busted/outputHandlers/junit.lua
@@ -11,10 +11,10 @@ return function(options, busted)
       errors = 0,
       failures = 0,
       skip = 0,
-      timestamp = os.date('!%Y-%m-%dT%T'),
     })
   }
   local stack = {}
+  local testStartTime
 
   handler.suiteStart = function(count, total)
     local suite = {
@@ -25,6 +25,7 @@ return function(options, busted)
         errors = 0,
         failures = 0,
         skip = 0,
+        timestamp = os.date('!%Y-%m-%dT%T'),
       })
     }
     top.xml_doc:add_direct_child(suite.xml_doc)


### PR DESCRIPTION
Insert timestamp in each test suite header instead of the overall header for all test suites.