### PR TITLE
Update error messages

### DIFF
--- a/busted/languages/en.lua
+++ b/busted/languages/en.lua
@@ -25,6 +25,8 @@ s:set('output.success_single', 'success')
 
 s:set('output.seconds', 'seconds')
 
+s:set('output.no_test_files_match', 'No test files found matching Lua pattern: %s')
+
 -- definitions following are not used within the 'say' namespace
 return {
   failure_messages = {

--- a/busted/languages/fr.lua
+++ b/busted/languages/fr.lua
@@ -21,6 +21,8 @@ s:set('output.success_single', 'reussite')
 
 s:set('output.seconds', 'secondes')
 
+s:set('output.no_test_files_match', 'Aucun test n\'est pourrait trouvé qui corresponde au motif de Lua: %s')
+
 -- definitions following are not used within the 'say' namespace
 return {
   failure_messages = {

--- a/busted/modules/test_file_loader.lua
+++ b/busted/modules/test_file_loader.lua
@@ -70,6 +70,11 @@ return function(busted, loaders, options)
       end
     end
 
+    if #fileList == 0 then
+      local err = 'No test files found matching Lua pattern: ' .. pattern
+      busted.publish({ 'error' }, {}, nil, err, {})
+    end
+
     return fileList
   end
 

--- a/busted/modules/test_file_loader.lua
+++ b/busted/modules/test_file_loader.lua
@@ -1,3 +1,5 @@
+local s = require 'say'
+
 return function(busted, loaders, options)
   local path = require 'pl.path'
   local dir = require 'pl.dir'
@@ -71,8 +73,7 @@ return function(busted, loaders, options)
     end
 
     if #fileList == 0 then
-      local err = 'No test files found matching Lua pattern: ' .. pattern
-      busted.publish({ 'error' }, {}, nil, err, {})
+      busted.publish({ 'error' }, {}, nil, s('output.no_test_files_match'):format(pattern), {})
     end
 
     return fileList

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -331,10 +331,6 @@ return function(options)
   local pattern = cliArgs.pattern
   local testFileLoader = require 'busted.modules.test_file_loader'(busted, loaders, testFileLoaderOptions)
   local fileList = testFileLoader(rootFile, pattern)
-  if #fileList == 0 then
-    print('No test files found matching Lua pattern: ' .. pattern)
-    errors = errors + 1
-  end
 
   if not cliArgs.ROOT then
     local ctx = busted.context.get()

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -180,12 +180,17 @@ return function(options)
   local errors = 0
   local quitOnError = cliArgs['no-keep-going']
 
+  busted.subscribe({ 'error', 'output' }, function(element, parent, message)
+    print('Error: Cannot load output library: ' .. element.name .. '\n' .. message)
+    return nil, true
+  end)
+
+  busted.subscribe({ 'error', 'helper' }, function(element, parent, message)
+    print('Error: Cannot load helper script: ' .. element.name .. '\n' .. message)
+    return nil, true
+  end)
+
   busted.subscribe({ 'error' }, function(element, parent, message)
-    if element.descriptor == 'output' then
-      print('Error: Cannot load output library: ' .. element.name .. '\n' .. message)
-    elseif element.descriptor == 'helper' then
-      print('Error: Cannot load helper script: ' .. element.name .. '\n' .. message)
-    end
     errors = errors + 1
     busted.skipAll = quitOnError
     return nil, true

--- a/spec/cl_spec.lua
+++ b/spec/cl_spec.lua
@@ -476,7 +476,7 @@ describe('Tests error messages through the command line', function()
     error_start()
     local result = run(busted_cmd .. ' --pattern=cl_two_failures.lua$ --output=not_found_here')
     local errmsg = result:match('(.-)\n')
-    local expected = 'Cannot load output library: not_found_here'
+    local expected = 'Error: Cannot load output library: not_found_here'
     assert.is_equal(expected, errmsg)
     error_end()
   end)
@@ -487,7 +487,7 @@ describe('Tests error messages through the command line', function()
     local err = result:match('Error → .-:%d+: (.-)\n')
     local errmsg = result:match('(.-)\n')
     local expectedErr = "module 'not_found_here' not found:"
-    local expectedMsg = 'Cannot load helper script: not_found_here'
+    local expectedMsg = 'Error: Cannot load helper script: not_found_here'
     assert.is_equal(expectedErr, err)
     assert.is_equal(expectedMsg, errmsg)
     error_end()
@@ -499,7 +499,7 @@ describe('Tests error messages through the command line', function()
     local err = result:match('Error → (.-)\n')
     local errmsg = result:match('(.-)\n')
     local expectedErr = 'cannot open ./not_found_here.lua: No such file or directory'
-    local expectedMsg = 'Cannot load helper script: not_found_here.lua'
+    local expectedMsg = 'Error: Cannot load helper script: not_found_here.lua'
     assert.is_equal(normpath(expectedErr), err)
     assert.is_equal(expectedMsg, errmsg)
     error_end()

--- a/spec/cl_spec.lua
+++ b/spec/cl_spec.lua
@@ -602,12 +602,12 @@ describe('Tests random seed through the commandline', function()
     error_end()
   end)
 
-  it('test invalid seed value defaults to a valid seed value', function()
+  it('test invalid seed value exits with error', function()
     local success, exitcode
     error_start()
     success, exitcode = execute(busted_cmd .. ' --seed=abcd --pattern=cl_random_seed.lua$')
     assert.is_false(success)
-    assert.is_equal(2, exitcode) -- fails cl_random_seed test +1 error
+    assert.is_equal(1, exitcode)
     error_end()
   end)
 
@@ -661,6 +661,15 @@ describe('Tests repeat commandline option', function()
     success, exitcode = execute(busted_cmd .. ' --repeat=2 --pattern=cl_two_failures.lua$')
     assert.is_false(success)
     assert.is_equal(4, exitcode)
+    error_end()
+  end)
+
+  it('exits with error when repeat is invalid', function()
+    local success, exitcode
+    error_start()
+    success, exitcode = execute(busted_cmd .. ' --repeat=abc --pattern=cl_success.lua$')
+    assert.is_false(success)
+    assert.is_equal(1, exitcode)
     error_end()
   end)
 end)

--- a/spec/cl_spec.lua
+++ b/spec/cl_spec.lua
@@ -508,7 +508,7 @@ describe('Tests error messages through the command line', function()
   it('when no test files matching Lua pattern', function()
     error_start()
     local result = run(busted_cmd .. ' --output=plainTerminal --pattern=this_filename_does_simply_not_exist$')
-    local errmsg = result:match('(.-)\n')
+    local errmsg = result:match('Error → (.-)\n')
     local expected = 'No test files found matching Lua pattern: this_filename_does_simply_not_exist$'
     assert.is_equal(expected, errmsg)
     error_end()


### PR DESCRIPTION
Update error messages with "Error:" prefix and validate numeric command line options.