### PR TITLE
Fix passing arguments to helpers

### DIFF
--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -212,7 +212,7 @@ return function(options)
     suppressPending = cliArgs['suppress-pending'],
     language = cliArgs.lang,
     deferPrint = cliArgs['defer-print'],
-    arguments = utils.split(cliArgs.Xoutput or '', ',') or {}
+    arguments = cliArgs.Xoutput and utils.split(cliArgs.Xoutput, ',') or {}
   }
 
   local opath = utils.normpath(path.join(fpath, cliArgs.output))
@@ -322,7 +322,7 @@ return function(options)
     local helperOptions = {
       verbose = cliArgs.verbose,
       language = cliArgs.lang,
-      arguments = utils.split(cliArgs.Xhelper or '', ',') or {}
+      arguments = cliArgs.Xhelper and utils.split(cliArgs.Xhelper, ',') or {}
     }
 
     local hpath = utils.normpath(path.join(fpath, cliArgs.helper))


### PR DESCRIPTION
Runner currently passes array with an empty string to helpers if no arguments are provided using -X\<helper\> options. This causes error when helper calls cli_args:parse on args. The issue is that when `cliArgs.Xoutput` is nil, `utils.split(cliArgs.Xoutput or '', ',') or {}` == `utils.split('', ',') or {}` == `{''} or {}` == `{''}`.