### PR TITLE
Do not use colors on Windows if ANSICON is not defined

### DIFF
--- a/busted/outputHandlers/utfTerminal.lua
+++ b/busted/outputHandlers/utfTerminal.lua
@@ -1,6 +1,14 @@
-local colors = require 'term.colors'
 local s = require 'say'
 local pretty = require 'pl.pretty'
+
+local colors
+
+if package.config:sub(1,1) == '\\' and not os.getenv("ANSICON") then
+  -- Disable colors on Windows.
+  colors = setmetatable({}, {__index = function() return function(s) return s end end})
+else
+  colors = require 'term.colors'
+end
 
 return function(options, busted)
   local handler = require 'busted.outputHandlers.base'(busted)


### PR DESCRIPTION
This fixes an issue with #373: unlike ansicolors, lua-term does not disable colors on Windows where it is typically not supported.