### PR TITLE
Add a gtest style output handler

### DIFF
--- a/busted-2.0.rc7-0.rockspec
+++ b/busted-2.0.rc7-0.rockspec
@@ -62,6 +62,7 @@ build = {
     ['busted.outputHandlers.TAP']             = 'busted/outputHandlers/TAP.lua',
     ['busted.outputHandlers.json']            = 'busted/outputHandlers/json.lua',
     ['busted.outputHandlers.junit']           = 'busted/outputHandlers/junit.lua',
+    ['busted.outputHandlers.gtest']           = 'busted/outputHandlers/gtest.lua',
     ['busted.outputHandlers.sound']           = 'busted/outputHandlers/sound.lua',
 
     ['busted.languages.en']                   = 'busted/languages/en.lua',

--- a/busted-scm-0.rockspec
+++ b/busted-scm-0.rockspec
@@ -61,6 +61,7 @@ build = {
     ['busted.outputHandlers.TAP']             = 'busted/outputHandlers/TAP.lua',
     ['busted.outputHandlers.json']            = 'busted/outputHandlers/json.lua',
     ['busted.outputHandlers.junit']           = 'busted/outputHandlers/junit.lua',
+    ['busted.outputHandlers.gtest']           = 'busted/outputHandlers/gtest.lua',
     ['busted.outputHandlers.sound']           = 'busted/outputHandlers/sound.lua',
 
     ['busted.languages.en']                   = 'busted/languages/en.lua',

--- a/busted/execute.lua
+++ b/busted/execute.lua
@@ -31,7 +31,7 @@ return function(busted)
       end
 
       local root = busted.context.get()
-      busted.publish({ 'suite', 'start' }, i, runs)
+      busted.publish({ 'suite', 'start' }, i, runs, busted.randomize and busted.randomseed or nil)
       if block.setup(root) then
         busted.execute()
       end

--- a/busted/init.lua
+++ b/busted/init.lua
@@ -3,9 +3,9 @@ local function init(busted)
 
   local file = function(file)
     busted.wrap(file.run)
-    busted.publish({ 'file', 'start' }, file.name)
+    busted.publish({ 'file', 'start' }, file)
     block.execute('file', file)
-    busted.publish({ 'file', 'end' }, file.name)
+    busted.publish({ 'file', 'end' }, file)
   end
 
   local describe = function(describe)

--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -1,0 +1,289 @@
+local s = require 'say'
+local socket = require 'socket'
+local pretty = require 'pl.pretty'
+local term = require 'term'
+
+local colors
+
+local isatty = term.isatty(io.stdout) 
+local isWindows = package.config:sub(1,1) == '\\'
+
+if isWindows and not os.getenv("ANSICON") or not isatty then
+  colors = setmetatable({}, {__index = function() return function(s) return s end end})
+else
+  colors = require 'term.colors'
+end
+
+return function(options, busted)
+  local busted = require 'busted'
+  local handler = require 'busted.outputHandlers.base'()
+
+  local repeatSuiteString = '\nRepeating all tests (run %d of %d) . . .\n\n'
+  local randomizeString  = 'Note: Randomizing test order with a seed of %d.\n'
+  local suiteStartString = colors.green  ('[==========]') .. ' Running tests from scanned files.\n'
+  local globalSetup      = colors.green  ('[----------]') .. ' Global test environment setup.\n'
+  local fileStartString  = colors.green  ('[----------]') .. ' Running tests from %s\n'
+  local runString        = colors.green  ('[ RUN      ]') .. ' %s\n'
+  local successString    = colors.green  ('[       OK ]') .. ' %s (%.2f ms)\n'
+  local skippedString    = colors.yellow ('[ SKIPPED  ]') .. ' %s (%.2f ms)\n'
+  local failureString    = colors.red    ('[  FAILED  ]') .. ' %s (%.2f ms)\n'
+  local errorString      = colors.magenta('[  ERROR   ]') .. ' %s (%.2f ms)\n'
+  local fileEndString    = colors.green  ('[----------]') .. ' %d %s from %s (%.2f ms total)\n\n'
+  local globalTeardown   = colors.green  ('[----------]') .. ' Global test environment teardown.\n'
+  local suiteEndString   = colors.green  ('[==========]') .. ' %d %s from %d test %s ran. (%.2f ms total)\n'
+  local successStatus    = colors.green  ('[  PASSED  ]') .. ' %d %s.\n'
+
+  local summaryStrings = {
+    skipped = {
+      header = colors.yellow ('[ SKIPPED  ]') .. ' %d %s, listed below:\n',
+      test   = colors.yellow ('[ SKIPPED  ]') .. ' %s\n',
+      footer = ' %d SKIPPED %s\n',
+    },
+
+    failure = {
+      header = colors.red    ('[  FAILED  ]') .. ' %d %s, listed below:\n',
+      test   = colors.red    ('[  FAILED  ]') .. ' %s\n',
+      footer = ' %d FAILED %s\n',
+    },
+
+    error = {
+      header = colors.magenta('[  ERROR   ]') .. ' %d %s, listed below:\n',
+      test   = colors.magenta('[  ERROR   ]') .. ' %s\n',
+      footer = ' %d %s\n',
+    },
+  }
+
+  local fileCount = 0
+  local testCount = 0
+  local successCount = 0
+  local skippedCount = 0
+  local failureCount = 0
+  local errorCount = 0
+
+  local suiteStartTime
+  local fileStartTime
+  local testStartTime
+
+  local pendingDescription = function(pending)
+    local name = pending.name
+    local string = ''
+
+    if type(pending.message) == 'string' then
+      string = string .. pending.message .. '\n'
+    elseif pending.message ~= nil then
+      string = string .. pretty.write(pending.message) .. '\n'
+    end
+
+    return string
+  end
+
+  local failureDescription = function(failure)
+    local string
+    if type(failure.message) == 'string' then
+      string = failure.message
+    elseif failure.message == nil then
+      string = 'Nil error'
+    else
+      string = pretty.write(failure.message)
+    end
+
+    string = string .. '\n'
+
+    if options.verbose and failure.trace and failure.trace.traceback then
+      string = string .. failure.trace.traceback .. '\n'
+    end
+
+    return string
+  end
+
+  local getFileLine = function(element)
+    local fileline = ''
+    if element.trace or element.trace.short_src then
+      fileline = colors.cyan(element.trace.short_src) .. ' @ ' ..
+                 colors.cyan(element.trace.currentline) .. ': '
+    end
+    return fileline
+  end
+
+  local getTestList = function(status, count, list, getDescription)
+    local string = ''
+    local header = summaryStrings[status].header
+    if count > 0 and header then
+      local tests = (count == 1 and 'test' or 'tests')
+      local errors = (count == 1 and 'error' or 'errors')
+      string = header:format(count, status == 'error' and errors or tests)
+
+      local testString = summaryStrings[status].test
+      if testString then
+        for _, t in ipairs(list) do
+          local fullname = getFileLine(t.element) .. colors.bright(t.name)
+          string = string .. testString:format(fullname)
+          if options.deferPrint then
+            string = string .. getDescription(t)
+          end
+        end
+      end
+    end
+    return string
+  end
+
+  local getSummary = function(status, count)
+    local string = ''
+    local footer = summaryStrings[status].footer
+    if count > 0 and footer then
+      local tests = (count == 1 and 'TEST' or 'TESTS')
+      local errors = (count == 1 and 'ERROR' or 'ERRORS')
+      string = footer:format(count, status == 'error' and errors or tests)
+    end
+    return string
+  end
+
+  local getSummaryString = function()
+    local tests = (successCount == 1 and 'test' or 'tests')
+    local string = successStatus:format(successCount, tests)
+
+    string = string .. getTestList('skipped', skippedCount, handler.pendings, pendingDescription)
+    string = string .. getTestList('failure', failureCount, handler.failures, failureDescription)
+    string = string .. getTestList('error', errorCount, handler.errors, failureDescription)
+
+    string = string .. ((skippedCount + failureCount + errorCount) > 0 and '\n' or '')
+    string = string .. getSummary('skipped', skippedCount)
+    string = string .. getSummary('failure', failureCount)
+    string = string .. getSummary('error', errorCount)
+
+    return string
+  end
+
+  local getFullName = function(element)
+    return getFileLine(element) .. colors.bright(handler.getFullName(element))
+  end
+
+  handler.suiteReset = function()
+    fileCount = 0
+    testCount = 0
+    successCount = 0
+    skippedCount = 0
+    failureCount = 0
+    errorCount = 0
+
+    return nil, true
+  end
+
+  handler.suiteStart = function(count, total, randomseed)
+    suiteStartTime = socket.gettime()
+    if total > 1 then
+      io.write(repeatSuiteString:format(count, total))
+    end
+    if randomseed then
+      io.write(randomizeString:format(randomseed))
+    end
+    io.write(suiteStartString)
+    io.write(globalSetup)
+    io.flush()
+
+    return nil, true
+  end
+
+  handler.suiteEnd = function(count, total)
+    local elapsedTime_ms = (socket.gettime() - suiteStartTime) * 1000
+    local tests = (testCount == 1 and 'test' or 'tests')
+    local files = (fileCount == 1 and 'file' or 'files')
+    io.write(globalTeardown)
+    io.write(suiteEndString:format(testCount, tests, fileCount, files, elapsedTime_ms))
+    io.write(getSummaryString())
+    io.flush()
+
+    return nil, true
+  end
+
+  handler.fileStart = function(file)
+    fileStartTime = socket.gettime()
+    io.write(fileStartString:format(file.name))
+    io.flush()
+    return nil, true
+  end
+
+  handler.fileEnd = function(file)
+    local elapsedTime_ms = (socket.gettime() - fileStartTime) * 1000
+    local tests = (testCount == 1 and 'test' or 'tests')
+    fileCount = fileCount + 1
+    io.write(fileEndString:format(testCount, tests, file.name, elapsedTime_ms))
+    io.flush()
+    return nil, true
+  end
+
+  handler.testStart = function(element, parent)
+    testStartTime = socket.gettime()
+    io.write(runString:format(getFullName(element)))
+    io.flush()
+
+    return nil, true
+  end
+
+  handler.testEnd = function(element, parent, status, debug)
+    local elapsedTime_ms = (socket.gettime() - testStartTime) * 1000
+    local string
+
+    testCount = testCount + 1
+    if status == 'success' then
+      successCount = successCount + 1
+      string = successString
+    elseif status == 'pending' then
+      skippedCount = skippedCount + 1
+      string = skippedString
+    elseif status == 'failure' then
+      failureCount = failureCount + 1
+      string = failureString
+    elseif status == 'error' then
+      errorCount = errorCount + 1
+      string = errorString
+    end
+
+    io.write(string:format(getFullName(element), elapsedTime_ms))
+    io.flush()
+
+    return nil, true
+  end
+
+  handler.testFailure = function(element, parent, message, debug)
+    if not options.deferPrint then
+      io.write(failureDescription(handler.failures[#handler.failures]))
+      io.flush()
+    end
+    return nil, true
+  end
+
+  handler.testError = function(element, parent, message, debug)
+    if not options.deferPrint then
+      io.write(failureDescription(handler.errors[#handler.errors]))
+      io.flush()
+    end
+    return nil, true
+  end
+
+  handler.error = function(element, parent, message, debug)
+    if element.descriptor ~= 'it' then
+      if not options.deferPrint then
+        io.write(failureDescription(handler.errors[#handler.errors]))
+        io.flush()
+      end
+      errorCount = errorCount + 1
+    end
+
+    return nil, true
+  end
+
+  busted.subscribe({ 'suite', 'reset' }, handler.suiteReset)
+  busted.subscribe({ 'suite', 'start' }, handler.suiteStart)
+  busted.subscribe({ 'suite', 'end' }, handler.suiteEnd)
+  busted.subscribe({ 'file', 'start' }, handler.fileStart)
+  busted.subscribe({ 'file', 'end' }, handler.fileEnd)
+  busted.subscribe({ 'test', 'start' }, handler.testStart, { predicate = handler.cancelOnPending })
+  busted.subscribe({ 'test', 'end' }, handler.testEnd, { predicate = handler.cancelOnPending })
+  busted.subscribe({ 'failure', 'it' }, handler.testFailure)
+  busted.subscribe({ 'error', 'it' }, handler.testError)
+  busted.subscribe({ 'failure' }, handler.error)
+  busted.subscribe({ 'error' }, handler.error)
+
+  return handler
+end

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -164,7 +164,7 @@ return function(options)
   local rootFiles = cliArgs.ROOT or { fileName }
   local pattern = cliArgs.pattern
   local testFileLoader = require 'busted.modules.test_file_loader'(busted, cliArgs.loaders)
-  local fileList = testFileLoader(rootFiles, pattern, testFileLoaderOptions)
+  testFileLoader(rootFiles, pattern, testFileLoaderOptions)
 
   -- If running standalone, setup test file to be compatible with live coding
   if not cliArgs.ROOT then


### PR DESCRIPTION
This outputs the test name before a test is run and outputs any failures/errors as they are encountered. The `--defer-print` option can be used to defer the output of failures/errors to the end of the test suite.

Basically adds an output handler that mirrors the gtest unit test output format (which seems to provide everything that #375 is asking for), adding error and skipped test detection.  Like gtest, this output handler will also display color when a tty is detected.

```
$ busted -o gtest 
[==========] Running tests from scanned files.
[----------] Global test environment setup.
[----------] Running tests from spec/test_spec.lua
[ RUN      ] spec/test_spec.lua @ 6: Tests success1
[       OK ] spec/test_spec.lua @ 6: Tests success1 (0.02 ms)
[ RUN      ] spec/test_spec.lua @ 9: Tests success2
[       OK ] spec/test_spec.lua @ 9: Tests success2 (0.02 ms)
[ RUN      ] spec/test_spec.lua @ 12: Tests failure1
spec/test_spec.lua:13: always fails
[  FAILED  ] spec/test_spec.lua @ 12: Tests failure1 (0.08 ms)
[ RUN      ] spec/test_spec.lua @ 16: Tests failure2
spec/test_spec.lua:17: always fails
[  FAILED  ] spec/test_spec.lua @ 16: Tests failure2 (0.08 ms)
[ RUN      ] spec/test_spec.lua @ 20: Tests error1
spec/test_spec.lua:21: always throws
[  ERROR   ] spec/test_spec.lua @ 20: Tests error1 (0.07 ms)
[ RUN      ] spec/test_spec.lua @ 24: Tests error2
spec/test_spec.lua:25: always throws
[  ERROR   ] spec/test_spec.lua @ 24: Tests error2 (0.07 ms)
[ RUN      ] spec/test_spec.lua @ 28: Tests pending1
[ SKIPPED  ] spec/test_spec.lua @ 28: Tests pending1 (0.01 ms)
[ RUN      ] spec/test_spec.lua @ 31: Tests test with pending
[ SKIPPED  ] spec/test_spec.lua @ 31: Tests test with pending (0.08 ms)
spec/test_spec.lua:3: error in teardown
[----------] 8 tests from spec/test_spec.lua (1.40 ms total)

[----------] Global test environment teardown.
[==========] 8 tests from 1 test file ran. (1.47 ms total)
[  PASSED  ] 2 tests.
[ SKIPPED  ] 2 tests, listed below:
[ SKIPPED  ] spec/test_spec.lua @ 28: Tests pending1
[ SKIPPED  ] spec/test_spec.lua @ 31: Tests test with pending
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] spec/test_spec.lua @ 12: Tests failure1
[  FAILED  ] spec/test_spec.lua @ 16: Tests failure2
[  ERROR   ] 3 errors, listed below:
[  ERROR   ] spec/test_spec.lua @ 20: Tests error1
[  ERROR   ] spec/test_spec.lua @ 24: Tests error2
[  ERROR   ] spec/test_spec.lua @ 2: Tests teardown

 2 SKIPPED TESTS
 2 FAILED TESTS
 3 ERRORS
```
```
$ busted --defer-print -o gtest
[==========] Running tests from scanned files.
[----------] Global test environment setup.
[----------] Running tests from spec/test_spec.lua
[ RUN      ] spec/test_spec.lua @ 6: Tests success1
[       OK ] spec/test_spec.lua @ 6: Tests success1 (0.02 ms)
[ RUN      ] spec/test_spec.lua @ 9: Tests success2
[       OK ] spec/test_spec.lua @ 9: Tests success2 (0.03 ms)
[ RUN      ] spec/test_spec.lua @ 12: Tests failure1
[  FAILED  ] spec/test_spec.lua @ 12: Tests failure1 (0.08 ms)
[ RUN      ] spec/test_spec.lua @ 16: Tests failure2
[  FAILED  ] spec/test_spec.lua @ 16: Tests failure2 (0.08 ms)
[ RUN      ] spec/test_spec.lua @ 20: Tests error1
[  ERROR   ] spec/test_spec.lua @ 20: Tests error1 (0.07 ms)
[ RUN      ] spec/test_spec.lua @ 24: Tests error2
[  ERROR   ] spec/test_spec.lua @ 24: Tests error2 (0.07 ms)
[ RUN      ] spec/test_spec.lua @ 28: Tests pending1
[ SKIPPED  ] spec/test_spec.lua @ 28: Tests pending1 (0.01 ms)
[ RUN      ] spec/test_spec.lua @ 31: Tests test with pending
[ SKIPPED  ] spec/test_spec.lua @ 31: Tests test with pending (0.08 ms)
[----------] 8 tests from spec/test_spec.lua (1.38 ms total)

[----------] Global test environment teardown.
[==========] 8 tests from 1 test file ran. (1.45 ms total)
[  PASSED  ] 2 tests.
[ SKIPPED  ] 2 tests, listed below:
[ SKIPPED  ] spec/test_spec.lua @ 28: Tests pending1
[ SKIPPED  ] spec/test_spec.lua @ 31: Tests test with pending
spec/test_spec.lua:32: pending2
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] spec/test_spec.lua @ 12: Tests failure1
spec/test_spec.lua:13: always fails
[  FAILED  ] spec/test_spec.lua @ 16: Tests failure2
spec/test_spec.lua:17: always fails
[  ERROR   ] 3 errors, listed below:
[  ERROR   ] spec/test_spec.lua @ 20: Tests error1
spec/test_spec.lua:21: always throws
[  ERROR   ] spec/test_spec.lua @ 24: Tests error2
spec/test_spec.lua:25: always throws
[  ERROR   ] spec/test_spec.lua @ 2: Tests teardown
spec/test_spec.lua:3: error in teardown

 2 SKIPPED TESTS
 2 FAILED TESTS
 3 ERRORS
```
