### PR TITLE
Export additional functions to external API

### DIFF
--- a/busted/core.lua
+++ b/busted/core.lua
@@ -46,7 +46,7 @@ return function()
 
   local environment = require 'busted.environment'(busted.context)
 
-  busted.modules = {}
+  busted.api = {}
   busted.executors = {}
   local executors = {}
   local eattributes = {}
@@ -178,7 +178,7 @@ return function()
   end
 
   function busted.exportApi(key, value)
-    busted.modules[key] = value
+    busted.api[key] = value
   end
 
   function busted.export(key, value)

--- a/busted/core.lua
+++ b/busted/core.lua
@@ -141,11 +141,11 @@ return function()
     throw(p)
   end
 
-  function busted.replaceErrorWithFail(callable)
+  function busted.bindfenv(callable, var, value)
     local env = {}
     local f = (getmetatable(callable) or {}).__call or callable
     setmetatable(env, { __index = getfenv(f) })
-    env.error = busted.fail
+    env[var] = value
     setfenv(f, env)
   end
 

--- a/busted/init.lua
+++ b/busted/init.lua
@@ -91,8 +91,8 @@ local function init(busted)
   busted.exportApi('subscribe', busted.subscribe)
   busted.exportApi('unsubscribe', busted.unsubscribe)
 
-  busted.replaceErrorWithFail(assert)
-  busted.replaceErrorWithFail(assert.is_true)
+  busted.bindfenv(assert, 'error', busted.fail)
+  busted.bindfenv(assert.is_true, 'error', busted.fail)
 
   return busted
 end

--- a/busted/init.lua
+++ b/busted/init.lua
@@ -91,6 +91,11 @@ local function init(busted)
   busted.exportApi('subscribe', busted.subscribe)
   busted.exportApi('unsubscribe', busted.unsubscribe)
 
+  busted.exportApi('bindfenv', busted.bindfenv)
+  busted.exportApi('fail', busted.fail)
+  busted.exportApi('parent', busted.context.parent)
+  busted.exportApi('version', busted.version)
+
   busted.bindfenv(assert, 'error', busted.fail)
   busted.bindfenv(assert.is_true, 'error', busted.fail)
 
@@ -103,7 +108,7 @@ return setmetatable({}, {
 
     return setmetatable(self, {
       __index = function(self, key)
-        return busted.modules[key]
+        return busted.api[key]
       end,
 
       __newindex = function(self, key, value)

--- a/busted/modules/filter_loader.lua
+++ b/busted/modules/filter_loader.lua
@@ -1,5 +1,5 @@
 return function()
-  local function filter(options, busted)
+  local function filter(busted, options)
     local getFullName = function(name)
       local parent = busted.context.get()
       local names = { name }

--- a/busted/modules/filter_loader.lua
+++ b/busted/modules/filter_loader.lua
@@ -70,7 +70,7 @@ return function()
     end
 
     local skipOnError = function()
-      return nil, not busted.skippAll
+      return nil, not busted.skipAll
     end
 
     local applyFilter = function(descriptors, name, fn)

--- a/busted/modules/helper_loader.lua
+++ b/busted/modules/helper_loader.lua
@@ -2,7 +2,7 @@ local utils = require 'busted.utils'
 local hasMoon, moonscript = pcall(require, 'moonscript')
 
 return function()
-  local loadHelper = function(helper, options, busted)
+  local loadHelper = function(busted, helper, options)
     local old_arg = arg
     local success, err = pcall(function()
       arg = options.arguments

--- a/busted/modules/output_handler_loader.lua
+++ b/busted/modules/output_handler_loader.lua
@@ -2,7 +2,7 @@ local utils = require 'busted.utils'
 local hasMoon, moonscript = pcall(require, 'moonscript')
 
 return function()
-  local loadOutputHandler = function(output, options, busted, defaultOutput)
+  local loadOutputHandler = function(busted, output, options, defaultOutput)
     local handler
 
     local success, err = pcall(function()
@@ -24,7 +24,7 @@ return function()
       handler = require('busted.outputHandlers.' .. defaultOutput)
     end
 
-    return handler(options, busted)
+    return handler(options)
   end
 
   return loadOutputHandler

--- a/busted/outputHandlers/TAP.lua
+++ b/busted/outputHandlers/TAP.lua
@@ -1,7 +1,8 @@
 local pretty = require 'pl.pretty'
 
-return function(options, busted)
-  local handler = require 'busted.outputHandlers.base'(busted)
+return function(options)
+  local busted = require 'busted'
+  local handler = require 'busted.outputHandlers.base'()
 
   handler.suiteEnd = function()
     local total = handler.successesCount + handler.errorsCount + handler.failuresCount

--- a/busted/outputHandlers/base.lua
+++ b/busted/outputHandlers/base.lua
@@ -1,4 +1,5 @@
-return function(busted)
+return function()
+  local busted = require 'busted'
   local handler = {
     successes = {},
     successesCount = 0,
@@ -36,14 +37,14 @@ return function(busted)
   end
 
   handler.getFullName = function(context)
-    local parent = busted.context.parent(context)
+    local parent = busted.parent(context)
     local names = { (context.name or context.descriptor) }
 
     while parent and (parent.name or parent.descriptor) and
           parent.descriptor ~= 'file' do
 
       table.insert(names, 1, parent.name or parent.descriptor)
-      parent = busted.context.parent(parent)
+      parent = busted.parent(parent)
     end
 
     return table.concat(names, ' ')

--- a/busted/outputHandlers/json.lua
+++ b/busted/outputHandlers/json.lua
@@ -1,7 +1,8 @@
 local json = require 'dkjson'
 
-return function(options, busted)
-  local handler = require 'busted.outputHandlers.base'(busted)
+return function(options)
+  local busted = require 'busted'
+  local handler = require 'busted.outputHandlers.base'()
 
   handler.suiteEnd = function()
     print(json.encode({

--- a/busted/outputHandlers/junit.lua
+++ b/busted/outputHandlers/junit.lua
@@ -2,8 +2,9 @@ local xml = require 'pl.xml'
 local socket = require("socket")
 local string = require("string")
 
-return function(options, busted)
-  local handler = require 'busted.outputHandlers.base'(busted)
+return function(options)
+  local busted = require 'busted'
+  local handler = require 'busted.outputHandlers.base'()
   local top = {
     start_time = socket.gettime(),
     xml_doc = xml.new('testsuites', {

--- a/busted/outputHandlers/plainTerminal.lua
+++ b/busted/outputHandlers/plainTerminal.lua
@@ -1,8 +1,9 @@
 local s = require 'say'
 local pretty = require 'pl.pretty'
 
-return function(options, busted)
-  local handler = require 'busted.outputHandlers.base'(busted)
+return function(options)
+  local busted = require 'busted'
+  local handler = require 'busted.outputHandlers.base'()
 
   local successDot =  '+'
   local failureDot =  '-'
@@ -132,6 +133,8 @@ return function(options, busted)
     local runString = (total > 1 and '\nRepeating all tests (run %d of %d) . . .\n\n' or '')
     io.write(runString:format(count, total))
     io.flush()
+
+    return nil, true
   end
 
   handler.suiteEnd = function()

--- a/busted/outputHandlers/sound.lua
+++ b/busted/outputHandlers/sound.lua
@@ -1,6 +1,7 @@
 local app = require 'pl.app'
-return function(options, busted)
-  local handler = require 'busted.outputHandlers.base'(busted)
+return function(options)
+  local busted = require 'busted'
+  local handler = require 'busted.outputHandlers.base'()
   local language = require('busted.languages.' .. options.language)
 
   handler.suiteEnd = function()

--- a/busted/outputHandlers/utfTerminal.lua
+++ b/busted/outputHandlers/utfTerminal.lua
@@ -10,8 +10,9 @@ else
   colors = require 'term.colors'
 end
 
-return function(options, busted)
-  local handler = require 'busted.outputHandlers.base'(busted)
+return function(options)
+  local busted = require 'busted'
+  local handler = require 'busted.outputHandlers.base'()
 
   local successDot = colors.green('●')
   local failureDot = colors.red('◼')
@@ -141,6 +142,8 @@ return function(options, busted)
     local runString = (total > 1 and '\nRepeating all tests (run %d of %d) . . .\n\n' or '')
     io.write(runString:format(count, total))
     io.flush()
+
+    return nil, true
   end
 
   handler.suiteEnd = function(count, total)

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -115,11 +115,11 @@ return function(options)
     arguments = cliArgs.Xoutput
   }
 
-  local outputHandler = outputHandlerLoader(cliArgs.output, outputHandlerOptions, busted, options.defaultOutput)
+  local outputHandler = outputHandlerLoader(busted, cliArgs.output, outputHandlerOptions, options.defaultOutput)
   outputHandler:subscribe(outputHandlerOptions)
 
   if cliArgs['enable-sound'] then
-    require 'busted.outputHandlers.sound'(outputHandlerOptions, busted)
+    require 'busted.outputHandlers.sound'(outputHandlerOptions)
   end
 
   -- Set up randomization options
@@ -138,7 +138,7 @@ return function(options)
   }
 
   -- Load tag and test filters
-  filterLoader(filterLoaderOptions, busted)
+  filterLoader(busted, filterLoaderOptions)
 
   -- Set up helper script
   if cliArgs.helper and cliArgs.helper ~= '' then
@@ -148,7 +148,7 @@ return function(options)
       arguments = cliArgs.Xhelper
     }
 
-    helperLoader(cliArgs.helper, helperOptions, busted)
+    helperLoader(busted, cliArgs.helper, helperOptions)
   end
 
   -- Set up test loader options

--- a/spec/cl_output_handler.lua
+++ b/spec/cl_output_handler.lua
@@ -1,7 +1,8 @@
 -- supporting testfile; belongs to 'cl_spec.lua'
 
-return function(options, busted)
-  local handler = require 'busted.outputHandlers.base'(busted)
+return function(options)
+  local busted = require 'busted'
+  local handler = require 'busted.outputHandlers.base'()
   local cli = require 'cliargs'
   local args = options.arguments
 

--- a/spec/export_spec.lua
+++ b/spec/export_spec.lua
@@ -70,6 +70,13 @@ describe('tests require "busted"', function()
     assert.is_equal(sub, unsub)
   end)
 
+  it('exports other functions/variables', function()
+    assert.is_function(require 'busted'.bindfenv)
+    assert.is_function(require 'busted'.fail)
+    assert.is_function(require 'busted'.parent)
+    assert.is_string(require 'busted'.version)
+  end)
+
   it('functions cannot be overwritten', function()
     local foo = function() assert(false) end
     assert.has_error(function() require 'busted'.it = foo end)


### PR DESCRIPTION
This exports additional functions/variables so they can be accessible to helper modules and output handlers.  With this change, output handlers no longer need to be passed the `busted` object.  Instead, they can just do `require 'busted'` and use the externally available API.
```lua
-- output handler
return function(options)
  local busted = require 'busted'
  local handler = require 'busted.outputhandlers.base'()
  ...
  busted.subscribe({'test', 'start'}, handler.testStart, { predicate = handler.cancelOnPending })
  busted.subscribe({'test', 'end'}, handler.testEnd, { predicate = handler.cancelOnPending })
  ...
end
```