### PR TITLE
Support disabling randomization in context blocks

### DIFF
--- a/busted/block.lua
+++ b/busted/block.lua
@@ -26,6 +26,7 @@ return function(busted)
 
   function block.rejectAll(element)
     block.reject('randomize', element)
+    block.reject('norandomize', element)
     for descriptor, _ in pairs(busted.executors) do
       block.reject(descriptor, element)
     end
@@ -135,6 +136,7 @@ return function(busted)
 
     local randomize = busted.randomize
     element.env.randomize = function() randomize = true end
+    element.env.norandomize = function() randomize = false end
 
     if busted.safe(descriptor, element.run, element):success() then
       if randomize then

--- a/spec/core_spec.lua
+++ b/spec/core_spec.lua
@@ -368,8 +368,9 @@ describe('tests unsupported functions', function()
     assert.has_error(strict_teardown, "'strict_teardown' not supported inside current context block")
   end)
 
-  it('it block throws error on randomize', function()
+  it('it block throws error on randomize/norandomize', function()
     assert.has_error(randomize, "'randomize' not supported inside current context block")
+    assert.has_error(norandomize, "'norandomize' not supported inside current context block")
   end)
 
   it('finaly block throws error on pending', function()
@@ -384,6 +385,7 @@ describe('tests unsupported functions in setup/before_each/after_each/teardown',
     assert.is_nil(file)
     assert.is_nil(finally)
     assert.has_error(randomize, "'randomize' not supported inside current context block")
+    assert.has_error(norandomize, "'norandomize' not supported inside current context block")
 
     assert.has_error(describe, "'describe' not supported inside current context block")
     assert.has_error(context, "'context' not supported inside current context block")

--- a/spec/randomize_spec.lua
+++ b/spec/randomize_spec.lua
@@ -18,3 +18,23 @@ describe('Order of tests ran', function()
     assert.are_not.same(unexpected, order)
   end)
 end)
+
+describe('Disabling randomized test order', function()
+  randomize()
+  norandomize()
+
+  local expected = {}
+  local order = {}
+
+  for i = 1, 100 do
+    table.insert(expected, i)
+
+    it('does 100 its', function()
+      table.insert(order, i)
+    end)
+  end
+
+  it('does not randomize tests', function()
+    assert.are.same(expected, order)
+  end)
+end)


### PR DESCRIPTION
This adds a `norandomize` function to file and describe contexts so that test randomization within the current context block can be explicitly disabled, overriding any command-line flags to enable randomization.
```lua
describe('Non-randomized tests', function()
  -- Disable randomization for current block when command-line flag forces randomization
  norandomize()
  ...
end)
```
As with the `randomize` function, `norandomize` does not apply to nested blocks.