### PR TITLE
Upgrade penlight version

### DIFF
--- a/busted-2.0.rc7-0.rockspec
+++ b/busted-2.0.rc7-0.rockspec
@@ -26,7 +26,7 @@ dependencies = {
   'luassert >= 1.7.4-0',
   'ansicolors >= 1.0-1',
   'lua-term >= 0.1-1',
-  'penlight >= 1.0.0-1',
+  'penlight >= 1.3.2-2',
   'mediator_lua >= 1.1-3',
 }
 build = {

--- a/busted-scm-0.rockspec
+++ b/busted-scm-0.rockspec
@@ -25,7 +25,7 @@ dependencies = {
   'say >= 1.3-0',
   'luassert >= 1.7.4-0',
   'lua-term >= 0.1-1',
-  'penlight >= 1.0.0-1',
+  'penlight >= 1.3.2-2',
   'mediator_lua >= 1.1-3',
 }
 build = {

--- a/busted/modules/cli.lua
+++ b/busted/modules/cli.lua
@@ -159,7 +159,7 @@ return function(options)
 
     -- Load busted config file if available
     local configFile = { }
-    local bustedConfigFilePath = cliArgs.f or utils.normpath(path.join(cliArgs.directory, '.busted'))
+    local bustedConfigFilePath = cliArgs.f or path.normpath(path.join(cliArgs.directory, '.busted'))
     local bustedConfigFile = pcall(function() configFile = loadfile(bustedConfigFilePath)() end)
     if bustedConfigFile then
       local config, err = configLoader(configFile, cliArgsParsed, cliArgs)

--- a/busted/modules/helper_loader.lua
+++ b/busted/modules/helper_loader.lua
@@ -1,4 +1,4 @@
-local utils = require 'busted.utils'
+local path = require 'pl.path'
 local hasMoon, moonscript = pcall(require, 'moonscript')
 
 return function()
@@ -7,9 +7,9 @@ return function()
     local success, err = pcall(function()
       arg = options.arguments
       if helper:match('%.lua$') then
-        dofile(utils.normpath(helper))
+        dofile(path.normpath(helper))
       elseif hasMoon and helper:match('%.moon$') then
-        moonscript.dofile(utils.normpath(helper))
+        moonscript.dofile(path.normpath(helper))
       else
         require(helper)
       end

--- a/busted/modules/output_handler_loader.lua
+++ b/busted/modules/output_handler_loader.lua
@@ -1,4 +1,4 @@
-local utils = require 'busted.utils'
+local path = require 'pl.path'
 local hasMoon, moonscript = pcall(require, 'moonscript')
 
 return function()
@@ -7,9 +7,9 @@ return function()
 
     local success, err = pcall(function()
       if output:match('%.lua$') then
-        handler = dofile(utils.normpath(output))
+        handler = dofile(path.normpath(output))
       elseif hasMoon and output:match('%.moon$') then
-        handler = moonscript.dofile(utils.normpath(output))
+        handler = moonscript.dofile(path.normpath(output))
       else
         handler = require('busted.outputHandlers.' .. output)
       end

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -44,7 +44,7 @@ return function(options)
   end
 
   -- Load current working directory
-  local _, err = path.chdir(utils.normpath(cliArgs.directory))
+  local _, err = path.chdir(path.normpath(cliArgs.directory))
   if err then
     io.stderr:write(appName .. ': error: ' .. err .. '\n')
     osexit(1, true)

--- a/busted/utils.lua
+++ b/busted/utils.lua
@@ -2,43 +2,8 @@ local path = require 'pl.path'
 
 math.randomseed(os.time())
 
--- Do not use pl.path.normpath
--- It is broken for paths with leading '../../'
-local function normpath(fpath)
-  if type(fpath) ~= 'string' then
-    error(fpath .. ' is not a string')
-  end
-  local sep = '/'
-  if path.is_windows then
-    sep = '\\'
-    if fpath:match '^\\\\' then -- UNC
-      return '\\\\' .. normpath(fpath:sub(3))
-    end
-    fpath = fpath:gsub('/','\\')
-  end
-  local np_gen1, np_gen2 = '([^SEP]+)SEP(%.%.SEP?)', 'SEP+%.?SEP'
-  local np_pat1 = np_gen1:gsub('SEP', sep)
-  local np_pat2 = np_gen2:gsub('SEP', sep)
-  local k
-  repeat -- /./ -> /
-    fpath, k = fpath:gsub(np_pat2, sep)
-  until k == 0
-  repeat -- A/../ -> (empty)
-    local oldpath = fpath
-    fpath, k = fpath:gsub(np_pat1, function(d, up)
-      if d == '..' then return nil end
-      if d == '.' then return up end
-      return ''
-    end)
-  until k == 0 or oldpath == fpath
-  if fpath == '' then fpath = '.' end
-  return fpath
-end
-
 return {
   split = require 'pl.utils'.split,
-
-  normpath = normpath,
 
   shuffle = function(t, seed)
     if seed then math.randomseed(seed) end

--- a/spec/cl_spec.lua
+++ b/spec/cl_spec.lua
@@ -1,6 +1,6 @@
 local utils = require 'pl.utils'
 local path = require 'pl.path'
-local normpath = require 'busted.utils'.normpath
+local normpath = path.normpath
 local busted_cmd = path.is_windows and 'lua bin/busted' or 'bin/busted'
 local ditch = path.is_windows and ' 1> NUL 2>NUL' or ' > /dev/null 2>&1'
 


### PR DESCRIPTION
This updates the version of penlight used by busted to the version of penlight that fixes `path.normpath`. With the updated version of penlight, busted no longer needs its own version of `normpath`, it can just use `path.normpath` directly from the penlight module.