### PR TITLE
Add missing luasocket dependency

### DIFF
--- a/busted-2.0.rc7-0.rockspec
+++ b/busted-2.0.rc7-0.rockspec
@@ -28,6 +28,7 @@ dependencies = {
   'lua-term >= 0.1-1',
   'penlight >= 1.0.0-1',
   'mediator_lua >= 1.1-3',
+  'luasocket >= 2.0.1'
 }
 build = {
   type = 'builtin',

--- a/busted-scm-0.rockspec
+++ b/busted-scm-0.rockspec
@@ -27,6 +27,7 @@ dependencies = {
   'lua-term >= 0.1-1',
   'penlight >= 1.0.0-1',
   'mediator_lua >= 1.1-3',
+  'luasocket >= 2.0.1'
 }
 build = {
   type = 'builtin',


### PR DESCRIPTION
The junit and gtest handlers both require luasocket in order to ```socket.gettime()```