### PR TITLE
Replace norandomize() with randomize(false)

### DIFF
--- a/busted/block.lua
+++ b/busted/block.lua
@@ -26,7 +26,6 @@ return function(busted)
 
   function block.rejectAll(element)
     block.reject('randomize', element)
-    block.reject('norandomize', element)
     for descriptor, _ in pairs(busted.executors) do
       block.reject(descriptor, element)
     end
@@ -135,8 +134,9 @@ return function(busted)
     if not element.env then element.env = {} end
 
     local randomize = busted.randomize
-    element.env.randomize = function() randomize = true end
-    element.env.norandomize = function() randomize = false end
+    element.env.randomize = function(...)
+      randomize = (select('#', ...) == 0 or ...)
+    end
 
     if busted.safe(descriptor, element.run, element):success() then
       if randomize then

--- a/spec/core_spec.lua
+++ b/spec/core_spec.lua
@@ -368,9 +368,8 @@ describe('tests unsupported functions', function()
     assert.has_error(strict_teardown, "'strict_teardown' not supported inside current context block")
   end)
 
-  it('it block throws error on randomize/norandomize', function()
+  it('it block throws error on randomize', function()
     assert.has_error(randomize, "'randomize' not supported inside current context block")
-    assert.has_error(norandomize, "'norandomize' not supported inside current context block")
   end)
 
   it('finaly block throws error on pending', function()
@@ -385,7 +384,6 @@ describe('tests unsupported functions in setup/before_each/after_each/teardown',
     assert.is_nil(file)
     assert.is_nil(finally)
     assert.has_error(randomize, "'randomize' not supported inside current context block")
-    assert.has_error(norandomize, "'norandomize' not supported inside current context block")
 
     assert.has_error(describe, "'describe' not supported inside current context block")
     assert.has_error(context, "'context' not supported inside current context block")

--- a/spec/randomize_spec.lua
+++ b/spec/randomize_spec.lua
@@ -19,9 +19,29 @@ describe('Order of tests ran', function()
   end)
 end)
 
-describe('Disabling randomized test order', function()
+describe('Disabling randomized test order with randomize(false)', function()
   randomize()
-  norandomize()
+  randomize(false)
+
+  local expected = {}
+  local order = {}
+
+  for i = 1, 100 do
+    table.insert(expected, i)
+
+    it('does 100 its', function()
+      table.insert(order, i)
+    end)
+  end
+
+  it('does not randomize tests', function()
+    assert.are.same(expected, order)
+  end)
+end)
+
+describe('Disabling randomized test order with randomize(nil)', function()
+  randomize()
+  randomize(nil)
 
   local expected = {}
   local order = {}


### PR DESCRIPTION
This removes the `norandomize` function  and overloads the `randomize` function to take an argument to enable/disable randomization. Calling `randomize` with no arguments enables randomization by default.
```lua
describe('Do not randomize in this block', function()
  randomize(false) -- or randomize(nil)
  ...
end)
```
```lua
describe('Force randomization in this block', function()
  randomize() -- or randomize(true)
  ...
end)
```
