### PR TITLE
Use git protocol in scm rockspec

### DIFF
--- a/busted-scm-0.rockspec
+++ b/busted-scm-0.rockspec
@@ -1,7 +1,7 @@
 package = 'busted'
 version = 'scm-0'
 source = {
-  url = "https://github.com/Olivine-Labs/busted.git",
+  url = "git://github.com/Olivine-Labs/busted",
   branch = "master"
 }
 description = {


### PR DESCRIPTION
This undos the previous change to use https protocol for git since luarocks does not support https using git.