### PR TITLE
Remove unnecessary arg to gtest output handler

### DIFF
--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -14,7 +14,7 @@ else
   colors = require 'term.colors'
 end
 
-return function(options, busted)
+return function(options)
   local busted = require 'busted'
   local handler = require 'busted.outputHandlers.base'()
 


### PR DESCRIPTION
Removes unused argument to the gtest output handler.
