### PR TITLE
Wrap publish start/end messages in a safe call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ before_install:
 install:
   - sudo apt-get update -qq
   - sudo luarocks install luasec
-  - sudo apt-get install -qq libev-dev
-  - sudo luarocks install lua-ev
-  - sudo luarocks install copas
   - sudo luarocks install moonscript
   - sudo luarocks make busted-scm-0.rockspec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - sudo apt-get update -qq
   - sudo luarocks install luasec
   - sudo apt-get install -qq libev-dev
-  - sudo luarocks install lua-ev scm --server=http://luarocks.org/repositories/rocks-scm/
+  - sudo luarocks install lua-ev
   - sudo luarocks install copas
   - sudo luarocks install moonscript
   - sudo luarocks make busted-scm-0.rockspec

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -6,7 +6,9 @@ set -e
 
 echo 'rocks_servers = {
   "http://rocks.moonscript.org/",
-  "http://luarocks.org/repositories/rocks"
+  "http://luarocks.org/repositories/rocks",
+  "http://luarocks.logiceditor.com/rocks",
+  "http://liblua.so/luarocks/repositories/rocks"
 }' >> ~/config.lua
 
 
@@ -29,7 +31,7 @@ else
 fi
 
 cd ..
-wget -O - http://luarocks.org/releases/luarocks-2.2.1.tar.gz | tar xz
+wget -O - http://luarocks.org/releases/luarocks-2.2.1.tar.gz | tar xz || wget -O - http://keplerproject.github.io/luarocks/releases/luarocks-2.2.1.tar.gz | tar xz
 cd luarocks-2.2.1
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -31,8 +31,8 @@ else
 fi
 
 cd ..
-wget -O - http://luarocks.org/releases/luarocks-2.2.1.tar.gz | tar xz || wget -O - http://keplerproject.github.io/luarocks/releases/luarocks-2.2.1.tar.gz | tar xz
-cd luarocks-2.2.1
+wget -O - http://luarocks.org/releases/luarocks-2.2.2.tar.gz | tar xz || wget -O - http://keplerproject.github.io/luarocks/releases/luarocks-2.2.2.tar.gz | tar xz
+cd luarocks-2.2.2
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then
   ./configure --with-lua-include=/usr/local/include/luajit-2.0;

--- a/busted/context.lua
+++ b/busted/context.lua
@@ -25,7 +25,7 @@ end
 return function()
   local context = {}
 
-  local data = {}
+  local data = { descriptor = 'suite', attributes = {} }
   local parents = {}
   local children = {}
   local stack = {}
@@ -87,7 +87,7 @@ return function()
     end
 
     function ref.clear()
-      data = {}
+      data = { descriptor = 'suite', attributes = {} }
       parents = {}
       children = {}
       stack = {}
@@ -110,7 +110,7 @@ return function()
     end
 
     function ref.push(current)
-      if not parents[current] then error('Detached child. Cannot push.') end
+      if not parents[current] and current ~= data then error('Detached child. Cannot push.') end
       if ctx ~= current then push_state(current) end
       table.insert(stack, ctx)
       ctx = current

--- a/busted/core.lua
+++ b/busted/core.lua
@@ -177,6 +177,15 @@ return function()
     return unpack(ret)
   end
 
+  function busted.safe_publish(descriptor, channel, element, ...)
+    local args = {...}
+    local n = select('#', ...)
+    local status = busted.safe(descriptor, function()
+      busted.publish(channel, element, unpack(args, 1, n))
+    end, element)
+    return status:success()
+  end
+
   function busted.exportApi(key, value)
     busted.api[key] = value
   end

--- a/busted/execute.lua
+++ b/busted/execute.lua
@@ -31,13 +31,15 @@ return function(busted)
       end
 
       local root = busted.context.get()
-      busted.publish({ 'suite', 'start' }, i, runs, busted.randomize and busted.randomseed or nil)
-      if block.setup(root) then
-        busted.execute()
+      local seed = (busted.randomize and busted.randomseed or nil)
+      if busted.safe_publish('suite', { 'suite', 'start' }, root, i, runs, seed) then
+        if block.setup(root) then
+          busted.execute()
+        end
+        block.lazyTeardown(root)
+        block.teardown(root)
       end
-      block.lazyTeardown(root)
-      block.teardown(root)
-      busted.publish({ 'suite', 'end' }, i, runs)
+      busted.safe_publish('suite', { 'suite', 'end' }, root, i, runs)
 
       if busted.skipAll then
         break

--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -169,7 +169,7 @@ return function(options)
     return nil, true
   end
 
-  handler.suiteStart = function(count, total, randomseed)
+  handler.suiteStart = function(suite, count, total, randomseed)
     suiteStartTime = socket.gettime()
     if total > 1 then
       io.write(repeatSuiteString:format(count, total))
@@ -184,7 +184,7 @@ return function(options)
     return nil, true
   end
 
-  handler.suiteEnd = function(count, total)
+  handler.suiteEnd = function(suite, count, total)
     local elapsedTime_ms = (socket.gettime() - suiteStartTime) * 1000
     local tests = (testCount == 1 and 'test' or 'tests')
     local files = (fileCount == 1 and 'file' or 'files')

--- a/busted/outputHandlers/junit.lua
+++ b/busted/outputHandlers/junit.lua
@@ -18,7 +18,7 @@ return function(options)
   local testcase_node
   local testStartTime
 
-  handler.suiteStart = function(count, total)
+  handler.suiteStart = function(suite, count, total)
     local suite = {
       start_time = socket.gettime(),
       xml_doc = xml.new('testsuite', {
@@ -41,7 +41,7 @@ return function(options)
     return string.format("%.2f", (socket.gettime() - start_time))
   end
 
-  handler.suiteEnd = function(count, total)
+  handler.suiteEnd = function(suite, count, total)
     local suite = top
     suite.xml_doc.attr.time = elapsed(suite.start_time)
 

--- a/busted/outputHandlers/plainTerminal.lua
+++ b/busted/outputHandlers/plainTerminal.lua
@@ -129,7 +129,7 @@ return function(options)
     return nil, true
   end
 
-  handler.suiteStart = function(count, total)
+  handler.suiteStart = function(suite, count, total)
     local runString = (total > 1 and '\nRepeating all tests (run %d of %d) . . .\n\n' or '')
     io.write(runString:format(count, total))
     io.flush()

--- a/busted/outputHandlers/utfTerminal.lua
+++ b/busted/outputHandlers/utfTerminal.lua
@@ -138,7 +138,7 @@ return function(options)
     return nil, true
   end
 
-  handler.suiteStart = function(count, total)
+  handler.suiteStart = function(suite, count, total)
     local runString = (total > 1 and '\nRepeating all tests (run %d of %d) . . .\n\n' or '')
     io.write(runString:format(count, total))
     io.flush()
@@ -146,7 +146,7 @@ return function(options)
     return nil, true
   end
 
-  handler.suiteEnd = function(count, total)
+  handler.suiteEnd = function(suite, count, total)
     print('')
     print(statusString())
 


### PR DESCRIPTION
This wraps publishing of `start` and `end` messages in a `safe` call.  By wrapping `publish` in `safe` if an error is thrown in a `start` message handler, the `end` message will still be published and the current block will be skipped.  This makes `start` and `end` messages work similar to `setup` and `teardown` functions.
