### PR TITLE
Fix repeated values in nested test description output.

### DIFF
--- a/spec/core_spec.lua
+++ b/spec/core_spec.lua
@@ -260,6 +260,25 @@ teardown A
 
 end)
 
+it "Nested tests are described correctly" (function()
+  local statuses = busted.run_internal_test(function()
+    describe "Outermost description" (function()
+      describe "Outer description" (function()
+        describe "Inner description" (function()
+          describe "Innermost description" (function()
+            it "Inner assertion" (function()
+              assert(true)
+            end)
+          end)
+        end)
+      end)
+    end)
+  end)
+  
+  local status = statuses[1]
+  assert.is_equal('Outermost description / Outer description / Inner description / Innermost description / Inner assertion', status.description)
+end)
+
 it "Malformated Lua code gets reported correctly" (function()
   local filename = ".malformed_test.lua"
   local f = io.open(filename,"w")

--- a/src/core.lua
+++ b/src/core.lua
@@ -569,11 +569,7 @@ end
 
 busted.raw_describe = function(desc, more)
   local context = create_context(desc)
-
-  for _, parent in ipairs(current_context.parents) do
-    context:add_parent(parent)
-  end
-
+  
   context:add_parent(current_context)
 
   local old_context = current_context


### PR DESCRIPTION
This is a fix for the stable branch to address repeated description values in test descriptions. Currently, the deeper a test is nested, the more duplicates appear in each description (until they're unreadable).

This PR adds a test for the output description of specs nested within describe blocks.

Fix changes the `raw_describe` method so that it only adds the current_context to the new context's parent list, rather than also adding all of the current_context's parents as well.

Relates to #238

