### PR TITLE
Fix luarocks installation failure in travis CI.

### DIFF
--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -18,7 +18,7 @@ else
 fi
 
 cd ..
-curl http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
+curl -L http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
 cd luarocks-2.1.2
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then


### PR DESCRIPTION
http://luarocks.org/releases/luarocks-2.1.2.tar.gz now redirects to http://keplerproject.github.io/luarocks/releases/luarocks-2.1.2.tar.gz and the travis setup fails.

PR adds `-L` flag to allow curl in the travis setup, to follow redirects.