### PR TITLE
Minor refactors

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -1,3 +1,3 @@
 #!/usr/bin/env lua
 -- Busted command-line runner
-require 'busted.runner'({ batch = true })
+require 'busted.runner'({ standalone = false })

--- a/busted-2.0.rc10-0.rockspec
+++ b/busted-2.0.rc10-0.rockspec
@@ -36,6 +36,7 @@ build = {
     ['busted.context']                        = 'busted/context.lua',
     ['busted.environment']                    = 'busted/environment.lua',
     ['busted.compatibility']                  = 'busted/compatibility.lua',
+    ['busted.options']                        = 'busted/options.lua',
     ['busted.done']                           = 'busted/done.lua',
     ['busted.runner']                         = 'busted/runner.lua',
     ['busted.status']                         = 'busted/status.lua',

--- a/busted-scm-0.rockspec
+++ b/busted-scm-0.rockspec
@@ -36,6 +36,7 @@ build = {
     ['busted.context']                        = 'busted/context.lua',
     ['busted.environment']                    = 'busted/environment.lua',
     ['busted.compatibility']                  = 'busted/compatibility.lua',
+    ['busted.options']                        = 'busted/options.lua',
     ['busted.done']                           = 'busted/done.lua',
     ['busted.runner']                         = 'busted/runner.lua',
     ['busted.status']                         = 'busted/status.lua',

--- a/busted/compatibility.lua
+++ b/busted/compatibility.lua
@@ -32,8 +32,8 @@ return {
 
   unpack = table.unpack or unpack,
 
-  osexit = function(code, close)
-    if close and _VERSION == 'Lua 5.1' and
+  exit = function(code)
+    if _VERSION == 'Lua 5.1' and
       (type(jit) ~= 'table' or not jit.version or jit.version_num < 20000) then
       -- From Lua 5.1 manual:
       -- > The userdata itself is freed only in the next
@@ -56,6 +56,6 @@ return {
         end
       end
     end
-    os.exit(code, close)
+    os.exit(code, true)
   end,
 }

--- a/busted/modules/cli.lua
+++ b/busted/modules/cli.lua
@@ -108,7 +108,7 @@ return function(options)
   -- Load up the command-line interface options
   cli:add_flag('--version', 'prints the program version and exits', false, processOption)
 
-  if options.batch then
+  if not options.standalone then
     cli:optarg('ROOT', 'test script file/folder. Folders will be traversed for any file that matches the --pattern option.', 'spec', 999, processArgList)
 
     cli:add_option('-p, --pattern=PATTERN', 'only run test files matching the Lua pattern', defaultPattern, processOption)

--- a/busted/options.lua
+++ b/busted/options.lua
@@ -1,0 +1,4 @@
+return {
+  standalone = true,
+  defaultOutput = 'utfTerminal',
+}

--- a/busted/outputHandlers/base.lua
+++ b/busted/outputHandlers/base.lua
@@ -1,3 +1,5 @@
+local socket = require 'socket'
+
 return function()
   local busted = require 'busted'
   local handler = {
@@ -73,7 +75,7 @@ return function()
   end
 
   handler.baseSuiteStart = function()
-    handler.startTime = os.clock()
+    handler.startTime = socket.gettime()
     return nil, true
   end
 
@@ -92,7 +94,7 @@ return function()
   end
 
   handler.baseSuiteEnd = function()
-    handler.endTime = os.clock()
+    handler.endTime = socket.gettime()
     return nil, true
   end
 

--- a/busted/outputHandlers/plainTerminal.lua
+++ b/busted/outputHandlers/plainTerminal.lua
@@ -71,7 +71,7 @@ return function(options)
     local pendingString = s('output.pending_plural')
     local errorString = s('output.error_plural')
 
-    local ms = handler.getDuration()
+    local sec = handler.getDuration()
     local successes = handler.successesCount
     local pendings = handler.pendingsCount
     local failures = handler.failuresCount
@@ -101,7 +101,7 @@ return function(options)
       errorString = s('output.error_single')
     end
 
-    local formattedTime = ('%.6f'):format(ms):gsub('([0-9])0+$', '%1')
+    local formattedTime = ('%.6f'):format(sec):gsub('([0-9])0+$', '%1')
 
     return successes .. ' ' .. successString .. ' / ' ..
       failures .. ' ' .. failureString .. ' / ' ..

--- a/busted/outputHandlers/utfTerminal.lua
+++ b/busted/outputHandlers/utfTerminal.lua
@@ -80,7 +80,7 @@ return function(options)
     local pendingString = s('output.pending_plural')
     local errorString = s('output.error_plural')
 
-    local ms = handler.getDuration()
+    local sec = handler.getDuration()
     local successes = handler.successesCount
     local pendings = handler.pendingsCount
     local failures = handler.failuresCount
@@ -110,7 +110,7 @@ return function(options)
       errorString = s('output.error_single')
     end
 
-    local formattedTime = ('%.6f'):format(ms):gsub('([0-9])0+$', '%1')
+    local formattedTime = ('%.6f'):format(sec):gsub('([0-9])0+$', '%1')
 
     return colors.green(successes) .. ' ' .. successString .. ' / ' ..
       colors.red(failures) .. ' ' .. failureString .. ' / ' ..

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -1,6 +1,7 @@
 -- Busted command-line runner
 
 local path = require 'pl.path'
+local tablex = require 'pl.tablex'
 local term = require 'term'
 local utils = require 'busted.utils'
 local osexit = require 'busted.compatibility'.osexit
@@ -9,7 +10,7 @@ local loaded = false
 return function(options)
   if loaded then return else loaded = true end
 
-  local options = options or {}
+  options = tablex.update(require 'busted.options', options or {})
   options.defaultOutput = term.isatty(io.stdout) and 'utfTerminal' or 'plainTerminal'
 
   local busted = require 'busted.core'()

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -4,7 +4,7 @@ local path = require 'pl.path'
 local tablex = require 'pl.tablex'
 local term = require 'term'
 local utils = require 'busted.utils'
-local osexit = require 'busted.compatibility'.osexit
+local exit = require 'busted.compatibility'.exit
 local loaded = false
 
 return function(options)
@@ -35,20 +35,20 @@ return function(options)
   local cliArgs, err = cli:parse(arg)
   if not cliArgs then
     io.stderr:write(err .. '\n')
-    osexit(1, true)
+    exit(1)
   end
 
   if cliArgs.version then
     -- Return early if asked for the version
     print(busted.version)
-    osexit(0, true)
+    exit(0)
   end
 
   -- Load current working directory
   local _, err = path.chdir(path.normpath(cliArgs.directory))
   if err then
     io.stderr:write(appName .. ': error: ' .. err .. '\n')
-    osexit(1, true)
+    exit(1)
   end
 
   -- If coverage arg is passed in, load LuaCovsupport
@@ -181,12 +181,12 @@ return function(options)
 
   busted.publish({ 'exit' })
 
-  local exit = 0
+  local code = 0
   if failures > 0 or errors > 0 then
-    exit = failures + errors
-    if exit > 255 then
-      exit = 255
+    code = failures + errors
+    if code > 255 then
+      code = 255
     end
   end
-  osexit(exit, true)
+  exit(code)
 end

--- a/spec/modules/cli_spec.lua
+++ b/spec/modules/cli_spec.lua
@@ -5,7 +5,7 @@ describe('Tests command-line interface', function()
     local defaultOutput = 'default_output_handler'
     local lpath = './src/?.lua;./src/?/?.lua;./src/?/init.lua'
     local cpath = path.is_windows and './csrc/?.dll;./csrc/?/?.dll;' or './csrc/?.so;./csrc/?/?.so;'
-    local cli = require 'busted.modules.cli'({ batch = true, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
     local args = cli:parse({})
     assert.is_equal(defaultOutput, args.o)
     assert.is_equal(defaultOutput, args.output)
@@ -59,7 +59,7 @@ describe('Tests command-line interface', function()
   end)
 
   it('standalone options disables ROOT and --pattern', function()
-    local cli = require 'busted.modules.cli'()
+    local cli = require 'busted.modules.cli'({ standalone = true })
     local args = cli:parse({})
     assert.is_nil(args.ROOT)
     assert.is_nil(args.p)
@@ -197,7 +197,7 @@ describe('Tests command-line interface', function()
   end)
 
   it('specify ROOT arg and --pattern', function()
-    local cli = require 'busted.modules.cli'({ batch = true })
+    local cli = require 'busted.modules.cli'({ standalone = false })
     local args = cli:parse({ '-p', 'match_files', 'root_is_here' })
     assert.is_same({'root_is_here'}, args.ROOT)
     assert.is_equal('match_files', args.p)
@@ -205,7 +205,7 @@ describe('Tests command-line interface', function()
   end)
 
   it('specify multiple root paths', function()
-    local cli = require 'busted.modules.cli'({ batch = true })
+    local cli = require 'busted.modules.cli'({ standalone = false })
     local args = cli:parse({'root1_path', 'root2_path', 'root3_path'})
     assert.is_same({'root1_path', 'root2_path', 'root3_path'}, args.ROOT)
   end)
@@ -313,7 +313,7 @@ describe('Tests using .busted tasks', function()
     local defaultOutput = 'default_output_handler'
     local lpath = './src/?.lua;./src/?/?.lua;./src/?/init.lua'
     local cpath = path.is_windows and './csrc/?.dll;./csrc/?/?.dll;' or './csrc/?.so;./csrc/?/?.so;'
-    local cli = require 'busted.modules.cli'({ batch = true, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
     local args = cli:parse({ '--directory=spec/.hidden' })
     assert.is_equal(defaultOutput, args.o)
     assert.is_equal(defaultOutput, args.output)
@@ -370,7 +370,7 @@ describe('Tests using .busted tasks', function()
     local defaultOutput = 'default_output_handler'
     local lpath = './src/?.lua;./src/?/?.lua;./src/?/init.lua'
     local cpath = path.is_windows and './csrc/?.dll;./csrc/?/?.dll;' or './csrc/?.so;./csrc/?/?.so;'
-    local cli = require 'busted.modules.cli'({ batch = true, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
     local args = cli:parse({ '--config-file', 'spec/.hidden/.busted' })
     assert.is_equal(defaultOutput, args.o)
     assert.is_equal(defaultOutput, args.output)
@@ -424,7 +424,7 @@ describe('Tests using .busted tasks', function()
   end)
 
   it('load configuration options', function()
-    local cli = require 'busted.modules.cli'({ batch = true, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
     local args = cli:parse({ '--directory=spec/.hidden', '--run=test' })
     assert.is_equal('_test%.lua$', args.pattern)
     assert.is_same({'tests'}, args.ROOT)
@@ -436,7 +436,7 @@ describe('Tests using .busted tasks', function()
   end)
 
   it('load configuration options and override with command-line', function()
-    local cli = require 'busted.modules.cli'({ batch = true, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
     local args = cli:parse({ '--directory=spec/.hidden', '--run=test', '-t', 'tag1', '-p', 'patt', '--loaders=moonscript' })
     assert.is_equal('patt', args.pattern)
     assert.is_same({'tag1'}, args.tags)


### PR DESCRIPTION
A few refactors
* Default options
* Calls to `os.exit()`
* Use `socket.gettime()` instead of `os.clock()`
