### PR TITLE
Fix busted globals with strict.lua

### DIFF
--- a/busted/block.lua
+++ b/busted/block.lua
@@ -17,7 +17,7 @@ return function(busted)
 
   function block.reject(descriptor, element)
     local env = getfenv(element.run)
-    if rawget(env, descriptor) then
+    if env ~= _G and env[descriptor] or rawget(_G, descriptor) then
       element.env[descriptor] = function(...)
         error("'" .. descriptor .. "' not supported inside current context block", 2)
       end

--- a/busted/block.lua
+++ b/busted/block.lua
@@ -17,7 +17,7 @@ return function(busted)
 
   function block.reject(descriptor, element)
     local env = getfenv(element.run)
-    if env[descriptor] then
+    if rawget(env, descriptor) then
       element.env[descriptor] = function(...)
         error("'" .. descriptor .. "' not supported inside current context block", 2)
       end

--- a/busted/init.lua
+++ b/busted/init.lua
@@ -1,3 +1,22 @@
+after_each = false
+before_each = false
+context = false
+describe = false
+expose = false
+file = false
+insulate = false
+it = false
+lazy_setup = false
+lazy_teardown = false
+pending = false
+randomize = false
+setup = false
+spec = false
+strict_setup = false
+strict_teardown = false
+teardown = false
+test = false
+
 local function init(busted)
   local block = require 'busted.block'(busted)
 

--- a/busted/init.lua
+++ b/busted/init.lua
@@ -1,22 +1,3 @@
-after_each = false
-before_each = false
-context = false
-describe = false
-expose = false
-file = false
-insulate = false
-it = false
-lazy_setup = false
-lazy_teardown = false
-pending = false
-randomize = false
-setup = false
-spec = false
-strict_setup = false
-strict_teardown = false
-teardown = false
-test = false
-
 local function init(busted)
   local block = require 'busted.block'(busted)
 


### PR DESCRIPTION
Get undeclared variable error when using the default strict.lua (unmodified) when environment has not been setup (e.g in setup())

For example

    describe(function()
      setup(function() set_global = 1 end)
      it('test', function() assert.equal(set_global, 1) end)
    end)