### PR TITLE
Fix json output

### DIFF
--- a/busted/outputHandlers/base.lua
+++ b/busted/outputHandlers/base.lua
@@ -55,13 +55,17 @@ return function()
   handler.format = function(element, parent, message, debug, isError)
     local formatted = {
       trace = debug or element.trace,
-      element = element,
+      element = {
+        name = element.name,
+        descriptor = element.descriptor,
+        attributes = element.attributes,
+        trace = element.trace or debug,
+      },
       name = handler.getFullName(element),
       message = message,
       randomseed = parent and parent.randomseed,
       isError = isError
     }
-    formatted.element.trace = element.trace or debug
 
     return formatted
   end


### PR DESCRIPTION
Looks like the json module has issues with tables that have functions in them. So remove output tables that have functions.

Fixes issue #448.