### PR TITLE
Handle errors from __gc metamethods

### DIFF
--- a/busted/core.lua
+++ b/busted/core.lua
@@ -173,6 +173,11 @@ return function()
     end) }
 
     if not ret[1] then
+      if status == 'success' then
+        status = 'error'
+        trace = busted.getTrace(element, 3, ret[2])
+        message = busted.rewriteMessage(element, ret[2], trace)
+      end
       busted.publish({ status, descriptor }, element, busted.context.parent(element), message, trace)
     end
     ret[1] = busted.status(status)

--- a/spec/cl_gc_error.lua
+++ b/spec/cl_gc_error.lua
@@ -1,0 +1,9 @@
+-- supporting testfile; belongs to 'cl_spec.lua'
+
+describe('Runs test with garbage collection failure', function()
+  it('throws error in __gc metamethod', function()
+    setmetatable({}, { __gc = function() error('gc error') end})
+    collectgarbage()
+    collectgarbage()
+  end)
+end)


### PR DESCRIPTION
This handles errors from __gc metamethods as well as any other errors that are not caught by xpcall.