### PR TITLE
Refactor calls to module loaders

### DIFF
--- a/busted/modules/configuration_loader.lua
+++ b/busted/modules/configuration_loader.lua
@@ -1,6 +1,6 @@
-return function()
-  local tablex = require 'pl.tablex'
+local tablex = require 'pl.tablex'
 
+return function()
   -- Function to load the .busted configuration file if available
   local loadBustedConfigurationFile = function(configFile, config, defaults)
     if type(configFile) ~= 'table' then

--- a/busted/modules/output_handler_loader.lua
+++ b/busted/modules/output_handler_loader.lua
@@ -2,7 +2,7 @@ local path = require 'pl.path'
 local hasMoon, moonscript = pcall(require, 'moonscript')
 
 return function()
-  local loadOutputHandler = function(busted, output, options, defaultOutput)
+  local loadOutputHandler = function(busted, output, options)
     local handler
 
     local success, err = pcall(function()
@@ -21,10 +21,14 @@ return function()
 
     if not success then
       busted.publish({ 'error', 'output' }, { descriptor = 'output', name = output }, nil, err, {})
-      handler = require('busted.outputHandlers.' .. defaultOutput)
+      handler = require('busted.outputHandlers.' .. options.defaultOutput)
     end
 
-    return handler(options)
+    if options.enableSound then
+      require 'busted.outputHandlers.sound'(options)
+    end
+
+    handler(options):subscribe(options)
   end
 
   return loadOutputHandler


### PR DESCRIPTION
This just cleans up the calls to the various loaders (i.e. output handler, filter loader, helper loader).
