### PR TITLE
Fix unintentional stack trace on exit

### DIFF
--- a/busted/compatibility.lua
+++ b/busted/compatibility.lua
@@ -33,7 +33,11 @@ return {
   unpack = table.unpack or unpack,
 
   exit = function(code)
-    if code ~= 0 then error() end
+    if code ~= 0 and _VERSION:match('^Lua 5%.[12]$') then
+      error()
+    elseif code ~= 0 then
+      code = 1
+    end
     if _VERSION == 'Lua 5.1' and
       (type(jit) ~= 'table' or not jit.version or jit.version_num < 20000) then
       -- From Lua 5.1 manual:
@@ -57,6 +61,6 @@ return {
         end
       end
     end
-    os.exit(0, true)
+    os.exit(code, true)
   end,
 }


### PR DESCRIPTION
This fixes the stack trace on exiting with an error code on Lua 5.3.  On Lua 5.3, `error()` is not silent, so don't throw an `error()` to exit with error for Lua > 5.2. For Lua versions 5.1 and 5.2 continue to throw a silent `error()` to allow the Lua state to be closed naturally whenever possible.
