### PR TITLE
Implement option to choose the lua interpreter

### DIFF
--- a/busted/compatibility.lua
+++ b/busted/compatibility.lua
@@ -63,4 +63,6 @@ return {
     end
     os.exit(code, true)
   end,
+
+  execute = require 'pl.utils'.execute,
 }

--- a/spec/cl_spec.lua
+++ b/spec/cl_spec.lua
@@ -212,6 +212,12 @@ describe('Tests the busted command-line options', function()
     assert.is_equal(1, exitcode)
   end)
 
+  it('can switch interpreters', function()
+    local success, exitcode, out = executeBusted('--lua=spec/lua.lua spec/cl_success.lua')
+    assert.is_true(success)
+    assert.is_equal(0, exitcode)
+    assert.equal('bin/busted --ignore-lua --lua=spec/lua.lua spec/cl_success.lua\n', out)
+  end)
 end)
 
 describe('Tests failing tests through the commandline', function()

--- a/spec/lua.lua
+++ b/spec/lua.lua
@@ -1,0 +1,4 @@
+#!/usr/bin/env lua
+local exit = require 'busted.compatibility'.exit
+print(table.concat(arg, ' '))
+exit(0)


### PR DESCRIPTION
@ajacksified @leafo @calio @o-lim 

This is a giant hack, but it works! The correct fix is not in busted, but in luarocks. Currently, luarocks wraps binaries in a shell script that forces a particular interpreter on us, the one that luarocks is configured for.