### PR TITLE
Ensure that pre-release versions of lua_cliargs 3 aren't used as a dependency

### DIFF
--- a/busted-2.0.rc10-1.rockspec
+++ b/busted-2.0.rc10-1.rockspec
@@ -19,7 +19,7 @@ description = {
 }
 dependencies = {
   'lua >= 5.1',
-  'lua_cliargs >= 2.5-0, < 3.0',
+  'lua_cliargs >= 2.5-0, < 3.0.rc-1',
   'luafilesystem >= 1.5.0',
   'dkjson >= 2.1.0',
   'say >= 1.3-0',

--- a/busted-scm-0.rockspec
+++ b/busted-scm-0.rockspec
@@ -19,7 +19,7 @@ description = {
 }
 dependencies = {
   'lua >= 5.1',
-  'lua_cliargs >= 2.5-0, < 3.0',
+  'lua_cliargs >= 2.5-0, < 3.0.rc-1',
   'luafilesystem >= 1.5.0',
   'dkjson >= 2.1.0',
   'say >= 1.3-0',


### PR DESCRIPTION
lua_cliargs 3.0.rc-1 was released a few hours ago and unfortunately Luarocks determined that this was < 3.0. So, if you install the current busted 2.0 RC it will install this incompatible version of lua_cliargs.

This change ensures that no 3.0 RCs are installed for lua_cliargs.