### PR TITLE
Refactor copying of context in base output handler

### DIFF
--- a/busted-scm-0.rockspec
+++ b/busted-scm-0.rockspec
@@ -19,7 +19,7 @@ description = {
 }
 dependencies = {
   'lua >= 5.1',
-  'lua_cliargs >= 2.5-0, < 3.0.rc-1',
+  'lua_cliargs = 3.0-1',
   'luafilesystem >= 1.5.0',
   'dkjson >= 2.1.0',
   'say >= 1.3-0',

--- a/busted/outputHandlers/base.lua
+++ b/busted/outputHandlers/base.lua
@@ -53,19 +53,25 @@ return function()
   end
 
   handler.format = function(element, parent, message, debug, isError)
+    local function copyElement(e)
+      local copy = {}
+      for k,v in next, e do
+        if type(v) ~= 'function' and k ~= 'env' then
+          copy[k] = v
+        end
+      end
+      return copy
+    end
+
     local formatted = {
       trace = debug or element.trace,
-      element = {
-        name = element.name,
-        descriptor = element.descriptor,
-        attributes = element.attributes,
-        trace = element.trace or debug,
-      },
+      element = copyElement(element),
       name = handler.getFullName(element),
       message = message,
       randomseed = parent and parent.randomseed,
       isError = isError
     }
+    formatted.element.trace = element.trace or debug
 
     return formatted
   end


### PR DESCRIPTION
This allows for adding new keys to a test context without the need to change the output handlers in order to copy a new or changed key. We can't just copy the entire table, otherwise the json output handler will break. The `env` key and any values that evaluate to functions cannot be copied.