### PR TITLE
Add `match` to busted env and exported functions

### DIFF
--- a/busted-scm-0.rockspec
+++ b/busted-scm-0.rockspec
@@ -19,7 +19,7 @@ description = {
 }
 dependencies = {
   'lua >= 5.1',
-  'lua_cliargs >= 2.5-0, < 3.0.rc-1',
+  'lua_cliargs = 3.0-1',
   'luafilesystem >= 1.5.0',
   'dkjson >= 2.1.0',
   'say >= 1.3-0',

--- a/busted/init.lua
+++ b/busted/init.lua
@@ -89,11 +89,13 @@ local function init(busted)
   local spy    = require 'luassert.spy'
   local mock   = require 'luassert.mock'
   local stub   = require 'luassert.stub'
+  local match  = require 'luassert.match'
 
   busted.export('assert', assert)
   busted.export('spy', spy)
   busted.export('mock', mock)
   busted.export('stub', stub)
+  busted.export('match', match)
 
   busted.exportApi('publish', busted.publish)
   busted.exportApi('subscribe', busted.subscribe)

--- a/spec/core_spec.lua
+++ b/spec/core_spec.lua
@@ -10,6 +10,7 @@ assert(type(after_each) == 'function')
 assert(type(spy) == 'table')
 assert(type(stub) == 'table')
 assert(type(mock) == 'table')
+assert(type(match) == 'table')
 assert(type(assert) == 'table')
 
 describe('Before each', function()

--- a/spec/export_spec.lua
+++ b/spec/export_spec.lua
@@ -50,11 +50,12 @@ describe('tests require "busted"', function()
     assert.is_equal(after_each, require 'busted'.after_each)
   end)
 
-  it('exports assert and mocks', function()
+  it('exports assert, mocks, and matchers', function()
     assert.is_equal(assert, require 'busted'.assert)
     assert.is_equal(spy, require 'busted'.spy)
     assert.is_equal(mock, require 'busted'.mock)
     assert.is_equal(stub, require 'busted'.stub)
+    assert.is_equal(match, require 'busted'.match)
   end)
 
   it('exports publish/subscribe', function()


### PR DESCRIPTION
This adds the `match` function from `luassert` to the busted test environment and exports it as part of the busted public API.