### PR TITLE
Fix scm-rockspec with correct lua_cliargs version

### DIFF
--- a/busted-scm-0.rockspec
+++ b/busted-scm-0.rockspec
@@ -19,7 +19,7 @@ description = {
 }
 dependencies = {
   'lua >= 5.1',
-  'lua_cliargs >= 2.5-0, < 3.0.rc-1',
+  'lua_cliargs = 3.0-1',
   'luafilesystem >= 1.5.0',
   'dkjson >= 2.1.0',
   'say >= 1.3-0',


### PR DESCRIPTION
This fixes the scm rockspec to use correct version of lua_cliargs.