### PR TITLE
Refactor test execution timing

### DIFF
--- a/busted/core.lua
+++ b/busted/core.lua
@@ -192,6 +192,12 @@ return function()
   function busted.safe_publish(descriptor, channel, element, ...)
     local args = {...}
     local n = select('#', ...)
+    if channel[2] == 'start' then
+      element.starttime = busted.gettime()
+    elseif channel[2] == 'end' then
+      element.endtime = busted.gettime()
+      element.duration = element.starttime and (element.endtime - element.starttime)
+    end
     local status = busted.safe(descriptor, function()
       busted.publish(channel, element, unpack(args, 1, n))
     end, element)
@@ -261,7 +267,10 @@ return function()
         attributes = attributes or {},
         name = name,
         run = fn,
-        trace = trace
+        trace = trace,
+        starttime = nil,
+        endtime = nil,
+        duration = nil,
       }
 
       busted.context.attach(plugin)

--- a/busted/outputHandlers/base.lua
+++ b/busted/outputHandlers/base.lua
@@ -82,8 +82,8 @@ return function()
     return handler.endTime - handler.startTime
   end
 
-  handler.baseSuiteStart = function()
-    handler.startTime = busted.gettime()
+  handler.baseSuiteStart = function(suite)
+    handler.startTime = suite.starttime
     return nil, true
   end
 
@@ -101,8 +101,8 @@ return function()
     return nil, true
   end
 
-  handler.baseSuiteEnd = function()
-    handler.endTime = busted.gettime()
+  handler.baseSuiteEnd = function(suite)
+    handler.endTime = suite.endtime
     return nil, true
   end
 

--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -60,10 +60,6 @@ return function(options)
   local failureCount = 0
   local errorCount = 0
 
-  local suiteStartTime
-  local fileStartTime
-  local testStartTime
-
   local pendingDescription = function(pending)
     local name = pending.name
     local string = ''
@@ -171,7 +167,6 @@ return function(options)
   end
 
   handler.suiteStart = function(suite, count, total, randomseed)
-    suiteStartTime = busted.gettime()
     if total > 1 then
       io.write(repeatSuiteString:format(count, total))
     end
@@ -186,7 +181,7 @@ return function(options)
   end
 
   handler.suiteEnd = function(suite, count, total)
-    local elapsedTime_ms = (busted.gettime() - suiteStartTime) * 1000
+    local elapsedTime_ms = suite.duration * 1000
     local tests = (testCount == 1 and 'test' or 'tests')
     local files = (fileCount == 1 and 'file' or 'files')
     io.write(globalTeardown)
@@ -198,7 +193,6 @@ return function(options)
   end
 
   handler.fileStart = function(file)
-    fileStartTime = busted.gettime()
     fileTestCount = 0
     io.write(fileStartString:format(file.name))
     io.flush()
@@ -206,7 +200,7 @@ return function(options)
   end
 
   handler.fileEnd = function(file)
-    local elapsedTime_ms = (busted.gettime() - fileStartTime) * 1000
+    local elapsedTime_ms = file.duration * 1000
     local tests = (fileTestCount == 1 and 'test' or 'tests')
     fileCount = fileCount + 1
     io.write(fileEndString:format(fileTestCount, tests, file.name, elapsedTime_ms))
@@ -215,7 +209,6 @@ return function(options)
   end
 
   handler.testStart = function(element, parent)
-    testStartTime = busted.gettime()
     io.write(runString:format(getFullName(element)))
     io.flush()
 
@@ -223,7 +216,7 @@ return function(options)
   end
 
   handler.testEnd = function(element, parent, status, debug)
-    local elapsedTime_ms = (busted.gettime() - testStartTime) * 1000
+    local elapsedTime_ms = element.duration * 1000
     local string
 
     fileTestCount = fileTestCount + 1


### PR DESCRIPTION
Move the computation and recording of test execution time to the core and insert the start/end time and duration of each block into its context for output handlers to consume and report.

This should resolve issue #473