### PR TITLE
Allow junit output handler to save output to file

### DIFF
--- a/busted/outputHandlers/junit.lua
+++ b/busted/outputHandlers/junit.lua
@@ -17,6 +17,11 @@ return function(options)
   local stack = {}
   local testcase_node
   local testStartTime
+  local output_file_name
+  if 'table' == type(options.arguments) then
+    --the first argument should be the name of the xml file.
+    output_file_name = options.arguments[1]
+  end
 
   handler.suiteStart = function(suite, count, total)
     local suite = {
@@ -56,8 +61,18 @@ return function(options)
 
   handler.exit = function()
     top.xml_doc.attr.time = elapsed(top.start_time)
-    print(xml.tostring(top.xml_doc, '', '\t', nil, false))
-
+    local output_string = xml.tostring(top.xml_doc, '', '\t', nil, false)
+    local file
+    if 'string' == type(output_file_name) then
+      file = io.open(output_file_name, 'w+b' )
+    end
+    if file then
+      file:write(output_string)
+      file:write('\n')
+      file:close()
+    else
+      print(output_string)
+    end
     return nil, true
   end
 


### PR DESCRIPTION
When trying to hook busted's junit output module up to an internal
automated test system it is very challenging to determine what output
was written to stdout by tests, and what output was written to stdout by
tests and what output is part of the test summary in xml. The simplest
way to handle this is to allow junit to accept an argument naming a file
where the xml output should be written via the -Xoutput mechanism. This
patch adds this change to junit.