### PR TITLE
Fix to junit timestamp string format:

### DIFF
--- a/busted/outputHandlers/junit.lua
+++ b/busted/outputHandlers/junit.lua
@@ -27,7 +27,7 @@ return function(options)
         errors = 0,
         failures = 0,
         skip = 0,
-        timestamp = os.date('!%Y-%m-%dT%T'),
+        timestamp = os.date('!%Y-%m-%dT%H:%M:%S'),
       })
     }
     top.xml_doc:add_direct_child(suite.xml_doc)


### PR DESCRIPTION
I'm testing version 2.0.rc11-0 and having an issue with the junit output handler crashing lua.
After a little digging, I found it's related to the call to os.date to format the junit timestamp.  The date format string is `'!%Y-%m-%dT%T'`, however the %T format specifier doesn't seem to be available on my platform. Changing the %T to %H:%M:%S in accordance to the strftime documentation resolves the issue.