### PR TITLE
Fix bad escape sequence

### DIFF
--- a/spec/modules/cli_spec.lua
+++ b/spec/modules/cli_spec.lua
@@ -462,7 +462,7 @@ describe('Tests using .busted tasks', function()
     assert.is_nil(args)
     assert.has_match('^app: error: spec/.hidden/.busted_bad:8: ', err)
     assert.has_match("'doesnotexist'", err)
-    assert.has_match("\(a nil value\)", err)
+    assert.has_match("a nil value", err)
   end)
 
   it('detects invalid configuration file', function()


### PR DESCRIPTION
This fixes a bad escape sequence used in spec/modules/cli_spec.lua for the last PR. Should be using '%' as the escape character instead of '\'. However, in order to be compatible with Lua 5.3, remove the parens from the match string for the failing test.