### PR TITLE
Fix parameters sent to suite start

### DIFF
--- a/busted/execute.lua
+++ b/busted/execute.lua
@@ -39,8 +39,6 @@ return function(busted)
     end
 
     for i = 1, runs do
-      local seed = (busted.randomize and busted.randomseed or nil)
-
       if i > 1 then
         suite_reset()
         root = busted.context.get()
@@ -53,6 +51,7 @@ return function(busted)
         sort(busted.context.children(root))
       end
 
+      local seed = (busted.randomize and busted.randomseed or nil)
       if busted.safe_publish('suite', { 'suite', 'start' }, root, i, runs, seed) then
         if block.setup(root) then
           busted.execute()


### PR DESCRIPTION
This fixes the random seed value that is displayed by some output handlers.  When a test suite is repeated multiple times with shuffle enabled and no random seed specified, then a new random seed is generated and used for each complete run of the test suite.  However, the random seed being sent to suite start at the beginning of each suite is incorrect when multiple runs are requested. In such cases, the seed passed to suite start is actually the seed for the previous run and not the current run that is being started. This change passes to suite start the random seed being used for the current run.