### PR TITLE
Make test file order deterministic

### DIFF
--- a/busted/modules/test_file_loader.lua
+++ b/busted/modules/test_file_loader.lua
@@ -35,6 +35,7 @@ return function(busted, loaders)
       fileList = {}
     end
 
+    table.sort(fileList)
     return fileList
   end
 


### PR DESCRIPTION
This updates the test file loader to sort each group of test files it finds, preserving the order of any tests specified on the command-line.  As a result, the order of test files will be deterministic and will not
depend on the order that the files occur on the file-system.  This also makes shuffling test files reproducible across different systems when specifying the same random seed, assuming the version of Lua across these systems uses the same random number generator.