### PR TITLE
Support optional seed parameter to randomize()

### DIFF
--- a/busted/block.lua
+++ b/busted/block.lua
@@ -135,14 +135,18 @@ return function(busted)
     if not element.env then element.env = {} end
 
     local randomize = busted.randomize
+    local randomseed = busted.randomseed
     element.env.randomize = function(...)
       randomize = (select('#', ...) == 0 or ...)
+      if randomize then
+        randomseed = tonumber(({...})[1]) or tonumber(({...})[2]) or randomseed
+      end
     end
 
     if busted.safe(descriptor, element.run, element):success() then
       if randomize then
-        element.randomseed = busted.randomseed
-        shuffle(busted.context.children(element), busted.randomseed)
+        element.randomseed = randomseed
+        shuffle(busted.context.children(element), randomseed)
       elseif busted.sort then
         sort(busted.context.children(element))
       end

--- a/busted/execute.lua
+++ b/busted/execute.lua
@@ -39,8 +39,6 @@ return function(busted)
     end
 
     for i = 1, runs do
-      local seed = (busted.randomize and busted.randomseed or nil)
-
       if i > 1 then
         suite_reset()
         root = busted.context.get()
@@ -53,6 +51,7 @@ return function(busted)
         sort(busted.context.children(root))
       end
 
+      local seed = (busted.randomize and busted.randomseed or nil)
       if busted.safe_publish('suite', { 'suite', 'start' }, root, i, runs, seed) then
         if block.setup(root) then
           busted.execute()

--- a/busted/execute.lua
+++ b/busted/execute.lua
@@ -46,6 +46,7 @@ return function(busted)
       end
 
       if options.shuffle then
+        root.randomseed = busted.randomseed
         shuffle(busted.context.children(root), busted.randomseed)
       elseif options.sort then
         sort(busted.context.children(root))

--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -18,7 +18,7 @@ return function(options)
   local handler = require 'busted.outputHandlers.base'()
 
   local repeatSuiteString = '\nRepeating all tests (run %d of %d) . . .\n\n'
-  local randomizeString  = 'Note: Randomizing test order with a seed of %d.\n'
+  local randomizeString  = colors.yellow('Note: Randomizing test order with a seed of %d.\n')
   local suiteStartString = colors.green  ('[==========]') .. ' Running tests from scanned files.\n'
   local globalSetup      = colors.green  ('[----------]') .. ' Global test environment setup.\n'
   local fileStartString  = colors.green  ('[----------]') .. ' Running tests from %s\n'

--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -74,13 +74,13 @@ return function(options)
   end
 
   local failureDescription = function(failure)
-    local string
+    local string = failure.randomseed and ('Random seed: ' .. failure.randomseed .. '\n') or ''
     if type(failure.message) == 'string' then
-      string = failure.message
+      string = string .. failure.message
     elseif failure.message == nil then
-      string = 'Nil error'
+      string = string .. 'Nil error'
     else
-      string = pretty.write(failure.message)
+      string = string .. pretty.write(failure.message)
     end
 
     string = string .. '\n'

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -158,7 +158,6 @@ return function(options)
   testFileLoader(rootFiles, pattern, {
     verbose = cliArgs.verbose,
     recursive = cliArgs['recursive'],
-    seed = busted.randomseed
   })
 
   -- If running standalone, setup test file to be compatible with live coding

--- a/spec/randomize_spec.lua
+++ b/spec/randomize_spec.lua
@@ -1,5 +1,7 @@
 local unexpected = {}
 local order = {}
+local orderfixed1 = {}
+local orderfixed2 = {}
 
 describe('Randomizing test order', function()
   randomize()
@@ -13,9 +15,50 @@ describe('Randomizing test order', function()
   end
 end)
 
+describe('Randomizing test order with fixed seed as first arg', function()
+  randomize(3210)
+
+  for i = 1, 10 do
+    it('does 10 its', function()
+      table.insert(orderfixed1, i)
+    end)
+  end
+end)
+
+describe('Randomizing test order with fixed seed as second arg', function()
+  randomize(true, 56789)
+
+  for i = 1, 10 do
+    it('does 10 its', function()
+      table.insert(orderfixed2, i)
+    end)
+  end
+end)
+
 describe('Order of tests ran', function()
+  local function shuffle(t, seed)
+    math.randomseed(seed)
+    local n = #t
+    while n >= 1 do
+      local k = math.random(n)
+      t[n], t[k] = t[k], t[n]
+      n = n - 1
+    end
+    return t
+  end
+
   it('randomized', function()
     assert.are_not.same(unexpected, order)
+  end)
+
+  it('randomized with known random seed: 3210', function()
+    local t = {1,2,3,4,5,6,7,8,9,10}
+    assert.are.same(shuffle(t, 3210), orderfixed1)
+  end)
+
+  it('randomized with known random seed: 56789', function()
+    local t = {1,2,3,4,5,6,7,8,9,10}
+    assert.are.same(shuffle(t, 56789), orderfixed2)
   end)
 end)
 


### PR DESCRIPTION
This adds support for an optional random seed parameter to be specified to the `randomize()` function.
```lua
describe('Randomizing test order with fixed seed', function()
  randomize(123456) -- or randomize(true, 123456)

  it('some test', function()
    ...
  end)

  it('another test', function()
    ...
  end)

  it('yet another test', function()
    ...
  end)
end)
```
Or if you wanted your seed to be based on some random or pseudo-random input source
```lua
describe('Randomizing test order with using different random seeds', function()
  describe('Random test group', function())
    randomize(get_random_seed_from_device())
    ...
  end)

  describe('Another random test group', function())
    randomize(get_random_seed_from_device())
    ...
  end)

  describe('Yet another random test group', function())
    randomize(get_random_seed_from_device())
    ...
  end)
end)
```
