### PR TITLE
Fix TAP output handler for --suppress-pending option

### DIFF
--- a/busted/outputHandlers/TAP.lua
+++ b/busted/outputHandlers/TAP.lua
@@ -77,8 +77,8 @@ return function(options)
 
   busted.subscribe({ 'suite', 'reset' }, handler.suiteReset)
   busted.subscribe({ 'suite', 'end' }, handler.suiteEnd)
-  busted.subscribe({ 'test', 'start' }, handler.testStart)
-  busted.subscribe({ 'test', 'end' }, handler.testEnd)
+  busted.subscribe({ 'test', 'start' }, handler.testStart, { predicate = handler.cancelOnPending })
+  busted.subscribe({ 'test', 'end' }, handler.testEnd, { predicate = handler.cancelOnPending })
   busted.subscribe({ 'error' }, handler.error)
 
   return handler


### PR DESCRIPTION
This fixes a bug in the TAP output handler causing busted to exit with an error when the `--suppress-pending` command-line option is used.

Fixes issue #518