### PR TITLE
Support running standalone tests from stdin

### DIFF
--- a/busted-2.0.rc12-1.rockspec
+++ b/busted-2.0.rc12-1.rockspec
@@ -48,6 +48,7 @@ build = {
 
     ['busted.modules.configuration_loader']   = 'busted/modules/configuration_loader.lua',
     ['busted.modules.luacov']                 = 'busted/modules/luacov.lua',
+    ['busted.modules.standalone_loader']      = 'busted/modules/standalone_loader.lua',
     ['busted.modules.test_file_loader']       = 'busted/modules/test_file_loader.lua',
     ['busted.modules.output_handler_loader']  = 'busted/modules/output_handler_loader.lua',
     ['busted.modules.helper_loader']          = 'busted/modules/helper_loader.lua',

--- a/busted-scm-0.rockspec
+++ b/busted-scm-0.rockspec
@@ -48,6 +48,7 @@ build = {
 
     ['busted.modules.configuration_loader']   = 'busted/modules/configuration_loader.lua',
     ['busted.modules.luacov']                 = 'busted/modules/luacov.lua',
+    ['busted.modules.standalone_loader']      = 'busted/modules/standalone_loader.lua',
     ['busted.modules.test_file_loader']       = 'busted/modules/test_file_loader.lua',
     ['busted.modules.output_handler_loader']  = 'busted/modules/output_handler_loader.lua',
     ['busted.modules.helper_loader']          = 'busted/modules/helper_loader.lua',

--- a/busted/compatibility.lua
+++ b/busted/compatibility.lua
@@ -33,8 +33,8 @@ return {
   loadstring = loadstring or load,
   unpack = table.unpack or unpack,
 
-  exit = function(code)
-    if code ~= 0 and _VERSION:match('^Lua 5%.[12]$') then
+  exit = function(code, force)
+    if not force and code ~= 0 and _VERSION:match('^Lua 5%.[12]$') then
       error()
     elseif code ~= 0 then
       code = 1

--- a/busted/modules/cli.lua
+++ b/busted/modules/cli.lua
@@ -12,7 +12,7 @@ return function(options)
   local configLoader = require 'busted.modules.configuration_loader'()
 
   -- Default cli arg values
-  local defaultOutput = options.defaultOutput
+  local defaultOutput = options.output or 'utfTerminal'
   local defaultLoaders = 'lua,moonscript'
   local defaultPattern = '_spec'
   local defaultSeed = '/dev/urandom or os.time()'

--- a/busted/modules/standalone_loader.lua
+++ b/busted/modules/standalone_loader.lua
@@ -1,0 +1,28 @@
+local getTrace = function(filename, info)
+  local index = info.traceback:find('\n%s*%[C]')
+  info.traceback = info.traceback:sub(1, index)
+  return info
+end
+
+return function(busted)
+  local loadCurrentFile = function(info, options)
+    local filename = 'string'
+    if info.source:sub(1,1) == '@' or info.source:sub(1,1) == '=' then
+      filename = info.source:sub(2)
+    end
+
+    -- Setup test file to be compatible with live coding
+    if info.func then
+      local file = setmetatable({
+        getTrace = getTrace,
+        rewriteMessage = nil
+      }, {
+        __call = info.func
+      })
+
+      busted.executors.file(filename, file)
+    end
+  end
+
+  return loadCurrentFile
+end

--- a/busted/options.lua
+++ b/busted/options.lua
@@ -1,4 +1,4 @@
 return {
   standalone = true,
-  defaultOutput = 'utfTerminal',
+  output = nil,
 }

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -9,11 +9,11 @@ local loadstring = require 'busted.compatibility'.loadstring
 local loaded = false
 
 return function(options)
-  if loaded then return else loaded = true end
+  if loaded then return function() end else loaded = true end
 
   local isatty = io.type(io.stdout) == 'file' and term.isatty(io.stdout)
   options = tablex.update(require 'busted.options', options or {})
-  options.defaultOutput = isatty and 'utfTerminal' or 'plainTerminal'
+  options.output = options.output or (isatty and 'utfTerminal' or 'plainTerminal')
 
   local busted = require 'busted.core'()
 
@@ -124,7 +124,7 @@ return function(options)
 
   -- Set up output handler to listen to events
   outputHandlerLoader(busted, cliArgs.output, {
-    defaultOutput = options.defaultOutput,
+    defaultOutput = options.output,
     enableSound = cliArgs['enable-sound'],
     verbose = cliArgs.verbose,
     suppressPending = cliArgs['suppress-pending'],

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -29,28 +29,29 @@ return function(options)
   local level = 2
   local info = debug.getinfo(level, 'Sf')
   local source = info.source
-  local fileName = source:sub(1,1) == '@' and source:sub(2) or source
+  local fileName = source:sub(1,1) == '@' and source:sub(2) or nil
+  local forceExit = fileName == nil
 
   -- Parse the cli arguments
-  local appName = path.basename(fileName)
+  local appName = path.basename(fileName or 'busted')
   cli:set_name(appName)
   local cliArgs, err = cli:parse(arg)
   if not cliArgs then
     io.stderr:write(err .. '\n')
-    exit(1)
+    exit(1, forceExit)
   end
 
   if cliArgs.version then
     -- Return early if asked for the version
     print(busted.version)
-    exit(0)
+    exit(0, forceExit)
   end
 
   -- Load current working directory
   local _, err = path.chdir(path.normpath(cliArgs.directory))
   if err then
     io.stderr:write(appName .. ': error: ' .. err .. '\n')
-    exit(1)
+    exit(1, forceExit)
   end
 
   -- If coverage arg is passed in, load LuaCovsupport
@@ -152,22 +153,20 @@ return function(options)
     suppressPending = cliArgs['suppress-pending'],
   })
 
-  -- Load test directory
-  local rootFiles = cliArgs.ROOT or { fileName }
-  local patterns = cliArgs.pattern
-  local testFileLoader = require 'busted.modules.test_file_loader'(busted, cliArgs.loaders)
-  testFileLoader(rootFiles, patterns, {
-    excludes = cliArgs['exclude-pattern'],
-    verbose = cliArgs.verbose,
-    recursive = cliArgs['recursive'],
-  })
-
-  -- If running standalone, setup test file to be compatible with live coding
-  if options.standalone then
-    local ctx = busted.context.get()
-    local children = busted.context.children(ctx)
-    local file = children[#children]
-    debug.getmetatable(file.run).__call = info.func
+  if cliArgs.ROOT then
+    -- Load test directories/files
+    local rootFiles = cliArgs.ROOT
+    local patterns = cliArgs.pattern
+    local testFileLoader = require 'busted.modules.test_file_loader'(busted, cliArgs.loaders)
+    testFileLoader(rootFiles, patterns, {
+      excludes = cliArgs['exclude-pattern'],
+      verbose = cliArgs.verbose,
+      recursive = cliArgs['recursive'],
+    })
+  else
+    -- Running standalone, use standalone loader
+    local testFileLoader = require 'busted.modules.standalone_loader'(busted)
+    testFileLoader(info, { verbose = cliArgs.verbose })
   end
 
   local runs = cliArgs['repeat']
@@ -181,6 +180,6 @@ return function(options)
   busted.publish({ 'exit' })
 
   if options.standalone or failures > 0 or errors > 0 then
-    exit(failures + errors)
+    exit(failures + errors, forceExit)
   end
 end

--- a/spec/cl_spec.lua
+++ b/spec/cl_spec.lua
@@ -300,6 +300,12 @@ describe('Test busted running standalone', function()
     local success, errcnt = executeLua('spec/cl_standalone.lua --help')
     assert.is_false(success)
   end)
+
+  it('tests running with via stdin', function()
+    local success, errcnt = executeLua('< spec/cl_standalone.lua')
+    assert.is_false(success)
+    assert.is_equal(3, errcnt)
+  end)
 end)
 
 describe('Test busted command-line runner', function()

--- a/spec/modules/cli_spec.lua
+++ b/spec/modules/cli_spec.lua
@@ -6,7 +6,7 @@ describe('Tests command-line interface', function()
     local defaultOutput = 'default_output_handler'
     local lpath = './src/?.lua;./src/?/?.lua;./src/?/init.lua'
     local cpath = path.is_windows and './csrc/?.dll;./csrc/?/?.dll;' or './csrc/?.so;./csrc/?/?.so;'
-    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, output = defaultOutput })
     local args = cli:parse({})
     assert.is_equal(defaultOutput, args.o)
     assert.is_equal(defaultOutput, args.output)
@@ -330,7 +330,7 @@ describe('Tests using .busted tasks', function()
     local defaultOutput = 'default_output_handler'
     local lpath = './src/?.lua;./src/?/?.lua;./src/?/init.lua'
     local cpath = path.is_windows and './csrc/?.dll;./csrc/?/?.dll;' or './csrc/?.so;./csrc/?/?.so;'
-    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, output = defaultOutput })
     local args = cli:parse({ '--directory=spec/.hidden' })
     assert.is_equal(defaultOutput, args.o)
     assert.is_equal(defaultOutput, args.output)
@@ -389,7 +389,7 @@ describe('Tests using .busted tasks', function()
     local defaultOutput = 'default_output_handler'
     local lpath = './src/?.lua;./src/?/?.lua;./src/?/init.lua'
     local cpath = path.is_windows and './csrc/?.dll;./csrc/?/?.dll;' or './csrc/?.so;./csrc/?/?.so;'
-    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, output = defaultOutput })
     local args = cli:parse({ '--config-file', 'spec/.hidden/.busted' })
     assert.is_equal(defaultOutput, args.o)
     assert.is_equal(defaultOutput, args.output)
@@ -444,7 +444,7 @@ describe('Tests using .busted tasks', function()
   end)
 
   it('load configuration options', function()
-    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, output = defaultOutput })
     local args = cli:parse({ '--directory=spec/.hidden', '--run=test' })
     assert.is_same({'_test1%.lua$', '_test2%.lua$'}, args.pattern)
     assert.is_same({'_exclude1', '_exclude2'}, args['exclude-pattern'])
@@ -459,7 +459,7 @@ describe('Tests using .busted tasks', function()
   end)
 
   it('load configuration options and override with command-line', function()
-    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, output = defaultOutput })
     local args = cli:parse({ '--directory=spec/.hidden', '--run=test', '-t', 'tag1', '-p', 'patt', '--filter=fin', '--filter-out=fout', '--exclude-pattern', '', '--loaders=moonscript' })
     assert.is_same({'patt'}, args.pattern)
     assert.is_same({''}, args['exclude-pattern'])
@@ -473,7 +473,7 @@ describe('Tests using .busted tasks', function()
   end)
 
   it('detects error in configuration file', function()
-    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, output = defaultOutput })
     cli:set_name('app')
     local args, err = cli:parse({ '--config-file=spec/.hidden/.busted_bad', '--run=test' })
     assert.is_nil(args)
@@ -483,7 +483,7 @@ describe('Tests using .busted tasks', function()
   end)
 
   it('detects invalid configuration file', function()
-    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, output = defaultOutput })
     cli:set_name('myapp')
     local args, err = cli:parse({ '--config-file=spec/.hidden/.busted_empty' })
     assert.is_nil(args)
@@ -491,7 +491,7 @@ describe('Tests using .busted tasks', function()
   end)
 
   it('detects unknown/invalid task', function()
-    local cli = require 'busted.modules.cli'({ standalone = false, defaultOutput = defaultOutput })
+    local cli = require 'busted.modules.cli'({ standalone = false, output = defaultOutput })
     cli:set_name('appname')
     local args, err = cli:parse({ '--config-file=spec/.hidden/.busted', '--run=invalid' })
     assert.is_nil(args)


### PR DESCRIPTION
This adds support for running standalone tests via stdin to the Lua interpreter.

For example:
```
  lua < standalone_spec.lua
```
or
```
  cat standalone_spec.lua | lua
```