### PR TITLE
Fix junit testcase time

### DIFF
--- a/busted/outputHandlers/junit.lua
+++ b/busted/outputHandlers/junit.lua
@@ -101,7 +101,7 @@ return function(options)
 
   handler.testEnd = function(element, parent, status)
     top.xml_doc.attr.tests = top.xml_doc.attr.tests + 1
-    testcase_node.time = formatDuration(element.duration)
+    testcase_node:set_attrib("time", formatDuration(element.duration))
 
     if status == 'success' then
       testStatus(element, parent, nil, 'success')


### PR DESCRIPTION
The testcase time for junit output wasn't being output correctly.  This change will update the xml tag appropriately and include time in the output.