### PR TITLE
Make busted capitalization more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Busted
+busted
 ======
 
 [![Join the chat at https://gitter.im/Olivine-Labs/busted](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Olivine-Labs/busted?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
It appears that "busted" is normally spelled with a lowercase 'b'. It was capitalized in the header.