### PR TITLE
TAP handler: flush output immediately

### DIFF
--- a/busted/outputHandlers/TAP.lua
+++ b/busted/outputHandlers/TAP.lua
@@ -16,6 +16,7 @@ return function(options)
 
   handler.suiteEnd = function()
     print('1..' .. counter)
+    io.flush()
     return nil, true
   end
 
@@ -45,6 +46,7 @@ return function(options)
       local testName = fileline .. handler.getFullName(element)
       print('# ' .. testName)
     end
+    io.flush()
 
     return nil, true
   end
@@ -62,6 +64,7 @@ return function(options)
     elseif status == 'error' then
       showFailure(handler.errors[#handler.errors])
     end
+    io.flush()
 
     return nil, true
   end
@@ -71,6 +74,7 @@ return function(options)
       counter = counter + 1
       showFailure(handler.errors[#handler.errors])
     end
+    io.flush()
 
     return nil, true
   end


### PR DESCRIPTION
8a4d223c5ae4ace8d88d4ee3ca79020f6e67ae21 changed the TAP handler to
write results after each test, but the output is still buffered.

If a test hangs, the buffered results of many previous tests will never
be printed, and it's not clear which test caused the hang. Flushing the
output avoids this.

cc @o-lim