### PR TITLE
Use a unique ID on heading about insulate/expose

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,7 +358,7 @@ end)
 end)
 </code></pre>
 
-            <h4 id="describe-blocks">Describe: Insulate &amp; Expose blocks</h4>
+            <h4 id="insulate-expose-blocks">Describe: Insulate &amp; Expose blocks</h4>
             <p>
               <code>insulate</code> and <code>expose</code> blocks are
               <code>describe</code> aliases that control the level of sandboxing


### PR DESCRIPTION
This heading has the same ID as the heading above it about `describe` blocks in general. A unique heading makes it easier to link to this section.