### PR TITLE
fix(cli) fail if LuaCov is specified but unavailable

### DIFF
--- a/busted/modules/luacov.lua
+++ b/busted/modules/luacov.lua
@@ -4,7 +4,7 @@ return function()
     local result, luacov = pcall(require, 'luacov.runner')
 
     if not result then
-      return print('LuaCov not found on the system, try running without --coverage option, or install LuaCov first')
+      return nil, 'LuaCov not found on the system, try running without --coverage option, or install LuaCov first'
     end
 
     -- call it to start
@@ -16,6 +16,7 @@ return function()
     table.insert(luacov.configuration.exclude, 'luassert%.')
     table.insert(luacov.configuration.exclude, 'say%.')
     table.insert(luacov.configuration.exclude, 'pl%.')
+    return true
   end
 
   return loadLuaCov

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -56,7 +56,11 @@ return function(options)
 
   -- If coverage arg is passed in, load LuaCovsupport
   if cliArgs.coverage then
-    luacov()
+    local ok, err = luacov()
+    if not ok then
+      io.stderr:write(appName .. ': error: ' .. err .. '\n')
+      exit(1, forceExit)
+    end
   end
 
   -- If auto-insulate is disabled, re-register file without insulation


### PR DESCRIPTION
Fails with an error (to stderr) if `-c` was specified, but LuaCov is not available.
Previously it would just print to stdout and continue without coverage reporting.