### PR TITLE
fix source URL in rockspec for v2.0.0 release

### DIFF
--- a/rockspecs/busted-2.0.0-0.rockspec
+++ b/rockspecs/busted-2.0.0-0.rockspec
@@ -1,8 +1,8 @@
 package = 'busted'
 version = '2.0.0-0'
 source = {
-  url = 'https://github.com/Olivine-Labs/busted/archive/v2.0.0-0.tar.gz',
-  dir = 'busted-2.0.0-0'
+  url = 'https://github.com/Olivine-Labs/busted/archive/v2.0.0.tar.gz',
+  dir = 'busted-2.0.0'
 }
 description = {
   summary = 'Elegant Lua unit testing.',


### PR DESCRIPTION
As of the new release, the version referenced in the rockspec file's source URL is inaccessible. This commit changes it to match the tarball version on github (no `-0` suffix). I'm not sure if this is preferable to renaming the archive and its contained directory, but it works in local testing.