### PR TITLE
fix(ci) do not specify a rockspec, just build the only one there

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - luarocks install moonscript
 
 install:
-  - luarocks make busted-scm-0.rockspec
+  - luarocks make
 
 script: busted
 


### PR DESCRIPTION
Since the published rockspecs are in their own dir, the SCM one is the only one in the main folder and hence a `luarocks make` is enough to build the currently checked out branch. 