### PR TITLE
Update terra loader to use the global-injection of current Terra

### DIFF
--- a/busted/modules/files/terra.lua
+++ b/busted/modules/files/terra.lua
@@ -2,7 +2,7 @@ local path = require 'pl.path'
 
 local ret = {}
 local terra_available, terralib = not not terralib, terralib --grab the injected global if it exists
-if not ok then
+if not terra_available then
   terra_available, terralib = pcall(require, 'terra') --otherwise, attempt to load terra as a shared library
 end
 

--- a/busted/modules/files/terra.lua
+++ b/busted/modules/files/terra.lua
@@ -1,7 +1,7 @@
 local path = require 'pl.path'
 
 local ret = {}
-local ok, terralib = not not terralib, terralib --pcall(function() return require 'terralib' end)
+local ok, terralib = not not terralib, terralib
 
 local getTrace = function(filename, info)
   local index = info.traceback:find('\n%s*%[C]')

--- a/busted/modules/files/terra.lua
+++ b/busted/modules/files/terra.lua
@@ -1,7 +1,10 @@
 local path = require 'pl.path'
 
 local ret = {}
-local ok, terralib = not not terralib, terralib
+local ok, terralib = not not terralib, terralib --grab the injected global if it exists
+if not ok then
+  ok, terralib = pcall(require, 'terra') --otherwise, attempt to load terra as a shared library
+end
 
 local getTrace = function(filename, info)
   local index = info.traceback:find('\n%s*%[C]')

--- a/busted/modules/files/terra.lua
+++ b/busted/modules/files/terra.lua
@@ -18,7 +18,7 @@ end
 
 ret.load = function(busted, filename)
   if not terra_available then
-    error "unable to load terra"
+    error "unable to load terra, try running without terra language support enabled or installing terra."
   else
     local file, err = terralib.loadfile(filename)
     if not file then

--- a/busted/modules/files/terra.lua
+++ b/busted/modules/files/terra.lua
@@ -18,7 +18,7 @@ end
 
 ret.load = function(busted, filename)
   if not terra_available then
-    busted.publish({ 'error', 'file' }, { descriptor = 'file', name = filename }, nil, "unable to load terra", {})
+    error "unable to load terra"
   else
     local file, err = terralib.loadfile(filename)
     if not file then

--- a/busted/modules/files/terra.lua
+++ b/busted/modules/files/terra.lua
@@ -1,7 +1,7 @@
 local path = require 'pl.path'
 
 local ret = {}
-local ok, terralib = pcall(function() return require 'terralib' end)
+local ok, terralib = not not terralib, terralib --pcall(function() return require 'terralib' end)
 
 local getTrace = function(filename, info)
   local index = info.traceback:find('\n%s*%[C]')


### PR DESCRIPTION
A quick and simple fix to allow testing code from the latest version of terra rather than a four year old alpha build. Currently working.

Further revisions to come after changing terra to provide a requirable module to scripts running inside it that matches the library requireable from outside terra so that `require "terra"` will work.

That would allow using busted regardless of running it from the terra executable or luajit.