### PR TITLE
Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ busted
 
 [![Join the chat at https://gitter.im/Olivine-Labs/busted](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Olivine-Labs/busted?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![travis-ci status](https://secure.travis-ci.org/Olivine-Labs/busted.png)](http://travis-ci.org/#!/Olivine-Labs/busted/builds)
+[![travis-ci status](https://secure.travis-ci.org/Olivine-Labs/busted.png)](http://travis-ci.org/Olivine-Labs/busted/builds)
 
 busted is a unit testing framework with a focus on being **easy to
 use**. Supports Lua >= 5.1, luajit >= 2.0.0, and moonscript.


### PR DESCRIPTION
Hello! This PR is related to the build status badge in the README. 
The problem with the previous badge is that it doesn't link to the correct page in travis

**What was it like before:**
 [![travis-ci status](https://secure.travis-ci.org/Olivine-Labs/busted.png)](http://travis-ci.org/#!/Olivine-Labs/busted/builds) *Note this links to 
http://travis-ci.org/#!/Olivine-Labs/busted/builds*

**What is it like with this change:**  
[![travis-ci status](https://secure.travis-ci.org/Olivine-Labs/busted.png)](http://travis-ci.org/Olivine-Labs/busted/builds) *link: http://travis-ci.org/Olivine-Labs/busted/builds*

