### PR TITLE
Remove use of global variable

### DIFF
--- a/busted/outputHandlers/junit.lua
+++ b/busted/outputHandlers/junit.lua
@@ -16,6 +16,7 @@ return function(options)
   }
   local stack = {}
   local testcase_node
+  local output_file_name
   if 'table' == type(options.arguments) then
     --the first argument should be the name of the xml file.
     output_file_name = options.arguments[1]


### PR DESCRIPTION
Remove write to global variable

Without this running busted under OpenResty 1.15+ results in this warning printed to stdout:
```
root@e9980e927ece:/etc/nginx/spec# ./lua-tests.sh -o junit
2019/11/25 22:35:32 [warn] 732#732: *2 [lua] _G write guard:12: __newindex(): writing a global lua variable ('output_file_name') which may lead to race conditions between concurrent requests, so prefer the use
of 'local' variables
stack traceback:
        ...sty/luajit/share/lua/5.1/busted/outputHandlers/junit.lua:21: in function 'handler'
        ...t/share/lua/5.1/busted/modules/output_handler_loader.lua:33: in function 'outputHandlerLoader'
        /usr/lib/openresty/luajit/share/lua/5.1/busted/runner.lua:130: in function </usr/lib/openresty/luajit/share/lua/5.1/busted/runner.lua:11>
        /usr/bin/busted:36: in function 'file_gen'
        init_worker_by_lua:61: in function <init_worker_by_lua:59>
        [C]: in function 'xpcall'
        init_worker_by_lua:68: in function <init_worker_by_lua:66>, context: ngx.timer
```