### PR TITLE
fix(helper) exit when cli specified helper fails

### DIFF
--- a/busted/modules/helper_loader.lua
+++ b/busted/modules/helper_loader.lua
@@ -20,8 +20,9 @@ return function()
     arg = old_arg   --luacheck: ignore
 
     if not success then
-      busted.publish({ 'error', 'helper' }, { descriptor = 'helper', name = helper }, nil, err, {})
+      return nil, err
     end
+    return true
   end
 
   return loadHelper

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -140,13 +140,18 @@ return function(options)
   -- Pre-load the LuaJIT 'ffi' module if applicable
   require 'busted.luajit'()
 
-  -- Set up helper script
+  -- Set up helper script, must succeed to even start tests
   if cliArgs.helper and cliArgs.helper ~= '' then
-    helperLoader(busted, cliArgs.helper, {
+    local ok, err = helperLoader(busted, cliArgs.helper, {
       verbose = cliArgs.verbose,
       language = cliArgs.lang,
       arguments = cliArgs.Xhelper
     })
+    if not ok then
+      io.stderr:write(appName .. ': failed running the specified helper (' ..
+                      cliArgs.helper .. '), error: ' .. err .. '\n')
+      exit(1, forceExit)
+    end
   end
 
   -- Load tag and test filters

--- a/spec/cl_spec.lua
+++ b/spec/cl_spec.lua
@@ -453,21 +453,23 @@ describe('Tests error messages through the command line', function()
   end)
 
   it('when helper script not found', function()
-    local _, _, result, rerr = executeBusted('--output=plainTerminal --pattern=cl_two_failures.lua$ --helper=not_found_here 2>&1')
-    local err = result:match('Error %-> .-:%d+: (.-)\n')
-    local errmsg = rerr:match('(.-)\n')
+    local success, _, _, rerr = executeBusted('--output=plainTerminal --pattern=cl_two_failures.lua$ --helper=not_found_here 2>&1')
+    assert.is.False(success)
+    local err = rerr:match('error: .-:%d+: (.-)\n')
+    local errmsg = rerr:match('(.-), error:')
     local expectedErr = "module 'not_found_here' not found:"
-    local expectedMsg = 'busted: error: Cannot load helper script: not_found_here'
+    local expectedMsg = 'busted: failed running the specified helper (not_found_here)'
     assert.is_equal(expectedErr, err)
     assert.is_equal(expectedMsg, errmsg)
   end)
 
   it('when helper lua script not found', function()
-    local _, _, result, rerr = executeBusted('--output=plainTerminal --pattern=cl_two_failures.lua$ --helper=not_found_here.lua 2>&1')
-    local err = result:match('Error %-> (.-)\n')
+    local success, _, _, rerr = executeBusted('--output=plainTerminal --pattern=cl_two_failures.lua$ --helper=not_found_here.lua 2>&1')
+    assert.is.False(success)
+    local err = rerr:match('error: (.-)\n')
     local errmsg = rerr:match('(.-)\n')
     local expectedErr = 'cannot open not_found_here.lua: No such file or directory'
-    local expectedMsg = 'busted: error: Cannot load helper script: not_found_here.lua'
+    local expectedMsg = 'busted: failed running the specified helper (not_found_here.lua), error: cannot open not_found_here.lua: No such file or directory'
     assert.is_equal(expectedErr, err)
     assert.is_equal(expectedMsg, errmsg)
   end)


### PR DESCRIPTION
if the helper fails the tests should not run since the environment
is most likely not properly set up. This is a hard requirement.

fixes #549