### PR TITLE
feat(fixtures) add function to locate relative fixtures

### DIFF
--- a/busted/fixtures.lua
+++ b/busted/fixtures.lua
@@ -1,0 +1,17 @@
+local pl_path = require 'pl.path'
+
+return {
+  -- returns an absolute path to where the current test file is located.
+  -- @param sub_path [optional] a relative path to a file to be appended
+  fixture_path = function(sub_path)
+    local info = debug.getinfo(2)
+    path = info.source
+    if path:sub(1,1) == "@" then
+      path = path:sub(2, -1)
+    end
+    path = pl_path.abspath(path) -- based on PWD
+    path = pl_path.splitpath(path) -- drop filename, keep path only
+    path = pl_path.join(path, sub_path)
+    return pl_path.normpath(path, sub_path)
+  end,
+}

--- a/busted/init.lua
+++ b/busted/init.lua
@@ -93,11 +93,14 @@ local function init(busted)
   local stub   = require 'luassert.stub'
   local match  = require 'luassert.match'
 
+  local fixture_path = require('busted.fixtures').fixture_path
+
   busted.export('assert', assert)
   busted.export('spy', spy)
   busted.export('mock', mock)
   busted.export('stub', stub)
   busted.export('match', match)
+  busted.export('fixture_path', fixture_path)
 
   busted.exportApi('publish', busted.publish)
   busted.exportApi('subscribe', busted.subscribe)

--- a/spec/fixtures_spec.lua
+++ b/spec/fixtures_spec.lua
@@ -1,0 +1,20 @@
+local pl_path = require "pl.path"
+
+describe("fixtures:", function()
+
+  describe("fixture_path()", function()
+
+    it("returns the absolute fixture path", function()
+      local path = fixture_path("fixtures/myfile.txt")
+      assert.match("^.-busted[/\\]spec[/\\]fixtures[/\\]myfile.txt$", path)
+    end)
+
+    it("returns the absolute fixture path normalized", function()
+      local path = fixture_path("../fixtures/myfile.txt")
+      assert.match("^.-busted[/\\]fixtures[/\\]myfile.txt$", path)
+    end)
+
+  end)
+
+end)
+


### PR DESCRIPTION
By providing a relative path from the current test file it will
return an absolute path to the fixture.

Closes #644 