### PR TITLE
feat(fixtures) add helpers to read/load fixtures

### DIFF
--- a/busted/fixtures.lua
+++ b/busted/fixtures.lua
@@ -71,7 +71,7 @@ function fixtures.load(rel_path)
     error(("Error loading file '%s': %s"):format(tostring(rel_path), tostring(err)), 2)
   end
 
-  local func, err = loadstring(code, rel_path)
+  local func, err = (loadstring or load)(code, rel_path)
   if not func then
     error(("Error loading code from '%s': %s"):format(tostring(rel_path), tostring(err)), 2)
   end

--- a/busted/fixtures.lua
+++ b/busted/fixtures.lua
@@ -1,17 +1,83 @@
 local pl_path = require 'pl.path'
+local pl_utils = require 'pl.utils'
 
-return {
-  -- returns an absolute path to where the current test file is located.
-  -- @param sub_path [optional] a relative path to a file to be appended
-  fixture_path = function(sub_path)
-    local info = debug.getinfo(2)
-    local path = info.source
-    if path:sub(1,1) == "@" then
-      path = path:sub(2, -1)
-    end
-    path = pl_path.abspath(path) -- based on PWD
-    path = pl_path.splitpath(path) -- drop filename, keep path only
-    path = pl_path.join(path, sub_path)
-    return pl_path.normpath(path, sub_path)
-  end,
-}
+local fixtures = {}
+
+-- returns an absolute path to where the current test file is located.
+-- @param sub_path [optional] a relative path to, to be appended
+-- @return returns the (normalized) absolute path
+function fixtures.path(sub_path)
+  if type(sub_path) ~= "string" and type(sub_path) ~= "nil" then
+    error("bad argument to 'path' expected a string (relative filename) or nil, got: " .. type(sub_path), 2)
+  end
+
+  local info = debug.getinfo(1)
+  local myname = info.source -- path to this code file
+
+  local path
+  local level = 1
+  repeat
+    -- other functions in this module call this one as well, so traverse up the
+    -- stack until we find the first call from outside this module, that's
+    -- the file to use as a baseline for our relative search
+    level = level + 1
+    info = debug.getinfo(level)
+    path = info.source
+  until path ~= myname
+
+  if path:sub(1,1) == "@" then
+    path = path:sub(2, -1)
+  end
+  path = pl_path.abspath(path) -- based on PWD
+  path = pl_path.splitpath(path) -- drop filename, keep path only
+  path = pl_path.join(path, sub_path)
+  return pl_path.normpath(path, sub_path)
+end
+
+
+-- reads a file relative from the current test file.
+-- @param rel_path (string) the relative path to the file
+-- @param is_bin (boolean) whether to load the file as a binary file
+-- @return returns the file contents or errors on failure
+function fixtures.read(rel_path, is_bin)
+  if type(rel_path) ~= "string" then
+    error("bad argument to 'read' expected a string (relative filename), got: " .. type(rel_path), 2)
+  end
+
+  local fname = fixtures.path(rel_path)
+
+  local contents, err = pl_utils.readfile(fname, is_bin)
+  if not contents then
+    error(("Error reading file '%s': %s"):format(tostring(fname), tostring(err)), 2)
+  end
+
+  return contents
+end
+
+
+-- loads (and executes) a Lua-file relative from the current test file.
+-- @param rel_path (string) the relative path to the file
+-- @return returns the results of the executed file (similar to a module)
+function fixtures.load(rel_path)
+  if type(rel_path) ~= "string" then
+    error("bad argument to 'load' expected a string (relative filename), got: " .. type(rel_path), 2)
+  end
+  local extension = "lua"
+  if not rel_path:match("%."..extension.."$") then
+    rel_path = rel_path .. "." .. extension
+  end
+  local code, err = fixtures.read(rel_path)
+  if not code then
+    error(("Error loading file '%s': %s"):format(tostring(rel_path), tostring(err)), 2)
+  end
+
+  local func, err = loadstring(code, rel_path)
+  if not func then
+    error(("Error loading code from '%s': %s"):format(tostring(rel_path), tostring(err)), 2)
+  end
+
+  return func()
+end
+
+
+return fixtures

--- a/busted/init.lua
+++ b/busted/init.lua
@@ -93,14 +93,13 @@ local function init(busted)
   local stub   = require 'luassert.stub'
   local match  = require 'luassert.match'
 
-  local fixture_path = require('busted.fixtures').fixture_path
+  require 'busted.fixtures'  -- just load into the environment, not exposing it
 
   busted.export('assert', assert)
   busted.export('spy', spy)
   busted.export('mock', mock)
   busted.export('stub', stub)
   busted.export('match', match)
-  busted.export('fixture_path', fixture_path)
 
   busted.exportApi('publish', busted.publish)
   busted.exportApi('subscribe', busted.subscribe)

--- a/spec/.hidden/dont_execute_spec.lua
+++ b/spec/.hidden/dont_execute_spec.lua
@@ -1,2 +1,1 @@
 assert(false,'should not be executed')
-

--- a/spec/.hidden/some_file.lua
+++ b/spec/.hidden/some_file.lua
@@ -1,0 +1,1 @@
+return "hello world"

--- a/spec/fixtures_spec.lua
+++ b/spec/fixtures_spec.lua
@@ -1,18 +1,86 @@
+local fixtures = require 'busted.fixtures'
+
 describe("fixtures:", function()
 
-  describe("fixture_path()", function()
+  describe("path()", function()
 
     it("returns the absolute fixture path", function()
-      local path = fixture_path("fixtures/myfile.txt") -- luacheck: ignore
+      local path = fixtures.path("fixtures/myfile.txt")
       assert.match("^.-busted[/\\]spec[/\\]fixtures[/\\]myfile.txt$", path)
     end)
 
     it("returns the absolute fixture path normalized", function()
-      local path = fixture_path("../fixtures/myfile.txt") -- luacheck: ignore
+      local path = fixtures.path("../fixtures/myfile.txt")
       assert.match("^.-busted[/\\]fixtures[/\\]myfile.txt$", path)
     end)
 
+    it("errors on bad input", function()
+      assert.has.error(function()
+        fixtures.path(123) -- pass in a number
+      end, "bad argument to 'path' expected a string (relative filename) or nil, got: number")
+    end)
+
   end)
+
+
+
+  describe("read()", function()
+
+    it("returns the contents of a file", function()
+      local contents, err = fixtures.read("../spec/.hidden/dont_execute_spec.lua")
+      assert.is_nil(err)
+      assert.equal("assert(false,'should not be executed')\n", contents)
+    end)
+
+    it("errors on bad input", function()
+      assert.has.error(function()
+        fixtures.read(123) -- pass in a number
+      end, "bad argument to 'read' expected a string (relative filename), got: number")
+    end)
+
+    it("errors on read failure", function()
+      assert.has.error(function()
+        fixtures.read("./doesnt/really/exist")
+      end)
+    end)
+
+  end)
+
+
+  describe("load()", function()
+
+    it("returns the executed contents of a lua file", function()
+      local contents, err = fixtures.load("../spec/.hidden/some_file.lua")
+      assert.is_nil(err)
+      assert.equal("hello world", contents)
+    end)
+
+    it("returns the executed contents of a lua file, without specifying the extension", function()
+      local contents, err = fixtures.load("../spec/.hidden/some_file")
+      assert.is_nil(err)
+      assert.equal("hello world", contents)
+    end)
+
+    it("errors on bad input", function()
+      assert.has.error(function()
+        fixtures.load(123) -- pass in a number
+      end, "bad argument to 'load' expected a string (relative filename), got: number")
+    end)
+
+    it("errors on read failure", function()
+      assert.has.error(function()
+        fixtures.load("./doesnt/really/exist")
+      end)
+    end)
+
+    it("errors on compile failure", function()
+      assert.has.error(function()
+        fixtures.load("./cl_compile_fail.lua")
+      end)
+    end)
+
+  end)
+
 
 end)
 


### PR DESCRIPTION
Also moves the `fixture_path` function (see #646) from a global to the 'fixtures' module. This is non-breaking since that hasn't been released yet.

I really don't like the global `fixture_path` hence the move into a separate module

```lua
local fixtures = "busted.fixtures"

local absolute_path = fixtures.path("../file/some/where.txt")
local my_file = fixtures.read("../file/some/where.txt")
local my_mod = fixtures.load("../some/path/file.lua")
```
