### PR TITLE
Issue 666: restore globals set to nil in insulate block

### DIFF
--- a/busted/context.lua
+++ b/busted/context.lua
@@ -17,6 +17,12 @@ local function restore(state)
   for k,_ in next, _G, nil do
     rawset(_G, k, state.g[k])
   end
+  for k, v in next, state.g, nil do
+    -- reset globals that were set to nil during the insulation block
+    if rawget(_G, k) == nil then
+      rawset(_G, k, v)
+    end
+  end
   for k,_ in pairs(package.loaded) do
     package.loaded[k] = state.loaded[k]
   end

--- a/spec/insulate-expose_spec.lua
+++ b/spec/insulate-expose_spec.lua
@@ -35,6 +35,8 @@ describe('Tests insulation', function()
 end)
 
 insulate('Tests insulation with values set to nil', function()
+  -- The tests in this block need to be run in order, as we're testing state recovery between tests.
+
   _G.some_global = true
 
   describe('environment before insulate', function()

--- a/spec/insulate-expose_spec.lua
+++ b/spec/insulate-expose_spec.lua
@@ -34,6 +34,32 @@ describe('Tests insulation', function()
   end)
 end)
 
+insulate('Tests insulation with values set to nil', function()
+  _G.some_global = true
+
+  describe('environment before insulate', function()
+    it('has global', function()
+      assert.is_not_nil(some_global)
+      assert.is_not_nil(_G.some_global)
+    end)
+  end)
+
+  insulate('environment inside insulate', function()
+    it('sets global to nil', function()
+      _G.some_global = nil
+      assert.is_nil(some_global)
+      assert.is_nil(_G.some_global)
+    end)
+  end)
+
+  describe('environment after insulate', function()
+    it('has restored the global', function()
+      assert.is_not_nil(some_global)
+      assert.is_not_nil(_G.some_global)
+    end)
+  end)
+end)
+
 insulate('', function()
   describe('Tests expose', function()
     insulate('inside insulate block', function()


### PR DESCRIPTION
Seems to be an easy fix, though I'd love feedback on [the `if` in line 22](https://github.com/Olivine-Labs/busted/pull/667/files#diff-5334561e9923d607069a41208ac1b79280fa64d315d6335ae9561ea3809dde60R22) of context.lua: I _don't think_ that there's a reason to restore if `rawget(_G, k) ~= nil` (as then it'd be restored in the first loop), right? 

Fixes #666 