### PR TITLE
fix(output) enable color overrides for utf+gtest handlers

### DIFF
--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -1,5 +1,4 @@
 local pretty = require 'pl.pretty'
-local term = require 'term'
 local io = io
 local type = type
 local ipairs = ipairs
@@ -7,12 +6,11 @@ local string_format = string.format
 local io_write = io.write
 local io_flush = io.flush
 
+
 local colors
 
-local isatty = io.type(io.stdout) == 'file' and term.isatty(io.stdout)
-local isWindows = package.config:sub(1,1) == '\\'
-
-if isWindows and not os.getenv("ANSICON") or not isatty then
+if package.config:sub(1,1) == '\\' and not os.getenv("ANSICON") then
+  -- Disable colors on Windows.
   colors = setmetatable({}, {__index = function() return function(s) return s end end})
 else
   colors = require 'term.colors'

--- a/busted/outputHandlers/utfTerminal.lua
+++ b/busted/outputHandlers/utfTerminal.lua
@@ -1,5 +1,6 @@
 local s = require 'say'
 local pretty = require 'pl.pretty'
+local term = require 'term'
 local io = io
 local type = type
 local string_format = string.format
@@ -7,20 +8,41 @@ local string_gsub = string.gsub
 local io_write = io.write
 local io_flush = io.flush
 local pairs = pairs
-
-
 local colors
 
-if package.config:sub(1,1) == '\\' and not os.getenv("ANSICON") then
-  -- Disable colors on Windows.
-  colors = setmetatable({}, {__index = function() return function(s) return s end end})
-else
-  colors = require 'term.colors'
-end
+local isatty = io.type(io.stdout) == 'file' and term.isatty(io.stdout)
 
 return function(options)
   local busted = require 'busted'
   local handler = require 'busted.outputHandlers.base'()
+  local cli = require 'cliargs'
+  local args = options.arguments
+
+  cli:set_name('utfTerminal output handler')
+  cli:flag('--color', 'force use of color')
+  cli:flag('--plain', 'force use of no color')
+
+  local cliArgs, err = cli:parse(args)
+  if not cliArgs and err then
+    io.stderr:write(string.format('%s: %s\n\n', cli.name, err))
+    io.stderr:write(cli.printer.generate_help_and_usage().. '\n')
+    os.exit(1)
+  end
+
+  if cliArgs.plain then
+    colors = setmetatable({}, {__index = function() return function(s) return s end end})
+
+  elseif cliArgs.color then
+    colors = require 'term.colors'
+
+  else
+    if package.config:sub(1,1) == '\\' and not os.getenv("ANSICON") or not isatty then
+      -- Disable colors on Windows.
+      colors = setmetatable({}, {__index = function() return function(s) return s end end})
+    else
+      colors = require 'term.colors'
+    end
+  end
 
   local successDot = colors.green('●')
   local failureDot = colors.red('◼')

--- a/spec/cl_output_handler.lua
+++ b/spec/cl_output_handler.lua
@@ -10,7 +10,12 @@ return function(options)
   cli:flag('--time', 'show timestamps')
   cli:option('--time-format=FORMAT', 'format string according to strftime', '!%a %b %d %H:%M:%S %Y')
 
-  local cliArgs = cli:parse(args)
+  local cliArgs, err = cli:parse(args)
+  if not cliArgs and err then
+    io.stderr:write(string.format('%s: %s\n\n', cli.name, err))
+    io.stderr:write(cli.printer.generate_help_and_usage().. '\n')
+    os.exit(1)
+  end
 
   handler.testEnd = function(element, parent, status, debug)
     local showTime = cliArgs.time


### PR DESCRIPTION
this updates the color outputting handlers to take override options.

The 2 (utfTerminal and gtest) were not in sync to start with. The gtest one does not colorize output in CI runs since the stream is not a tty. This makes sense on local systems, but could use an override in CI to force the use of color.

Both outputters can now be forced by specifying outputter options;

- `--Xoutput "--color"` will force use of color
- `--Xoutput "--plain"` will force use without color
