### PR TITLE
fix(color) utf+gtest handlers now also set luassert color

### DIFF
--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -30,16 +30,20 @@ return function(options)
 
   if cliArgs.plain then
     colors = setmetatable({}, {__index = function() return function(s) return s end end})
+    assert:set_parameter("TableErrorHighlightColor", "none")
 
   elseif cliArgs.color then
     colors = require 'term.colors'
+    assert:set_parameter("TableErrorHighlightColor", "red")
 
   else
     if package.config:sub(1,1) == '\\' and not os.getenv("ANSICON") or not isatty then
       -- Disable colors on Windows.
       colors = setmetatable({}, {__index = function() return function(s) return s end end})
+      assert:set_parameter("TableErrorHighlightColor", "none")
     else
       colors = require 'term.colors'
+      assert:set_parameter("TableErrorHighlightColor", "red")
     end
   end
 

--- a/busted/outputHandlers/utfTerminal.lua
+++ b/busted/outputHandlers/utfTerminal.lua
@@ -31,16 +31,20 @@ return function(options)
 
   if cliArgs.plain then
     colors = setmetatable({}, {__index = function() return function(s) return s end end})
+    assert:set_parameter("TableErrorHighlightColor", "none")
 
   elseif cliArgs.color then
     colors = require 'term.colors'
+    assert:set_parameter("TableErrorHighlightColor", "red")
 
   else
     if package.config:sub(1,1) == '\\' and not os.getenv("ANSICON") or not isatty then
       -- Disable colors on Windows.
       colors = setmetatable({}, {__index = function() return function(s) return s end end})
+      assert:set_parameter("TableErrorHighlightColor", "none")
     else
       colors = require 'term.colors'
+      assert:set_parameter("TableErrorHighlightColor", "red")
     end
   end
 


### PR DESCRIPTION
previously luassert did its own detection. Now the override in
busted will set luassert coloring options

see https://github.com/Olivine-Labs/luassert/pull/185#issuecomment-1206088029 